### PR TITLE
Add API call to join contest with code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    packagingOptions {
+        exclude 'META-INF/rxjava.properties'
+    }
 }
 
 dependencies {
@@ -105,6 +109,14 @@ dependencies {
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     compile "com.google.code.gson:gson:2.7"
+
+    // RX
+    def rxjavaVersion = "2.0.4";
+    def rxjandroidVersion = "2.0.1";
+    def rxjavaRetrofitAdapterVersion = "1.0.0";
+    compile "io.reactivex.rxjava2:rxjava:$rxjavaVersion"
+    compile "io.reactivex.rxjava2:rxandroid:$rxjandroidVersion"
+    compile "com.jakewharton.retrofit:retrofit2-rxjava2-adapter:$rxjavaRetrofitAdapterVersion"
 
     def okhttpVersion = "3.5.0"
     compile "com.squareup.okhttp3:okhttp:$okhttpVersion"

--- a/app/src/androidTest/java/io/intrepid/contest/InstrumentationTestApplication.java
+++ b/app/src/androidTest/java/io/intrepid/contest/InstrumentationTestApplication.java
@@ -1,16 +1,18 @@
 package io.intrepid.contest;
 
+import android.os.AsyncTask;
+
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.rest.RestApi;
 import io.intrepid.contest.rest.RetrofitClient;
+import io.intrepid.contest.settings.SharedPreferencesManager;
+import io.intrepid.contest.settings.UserSettings;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 
 public class InstrumentationTestApplication extends ContestApplication {
     private static RestApi restApiOverride = null;
-
-    @Override
-    public PresenterConfiguration getPresenterConfiguration() {
-        return new PresenterConfiguration(restApiOverride != null ? restApiOverride : RetrofitClient.getApi());
-    }
+    private static UserSettings userSettingsOverride = null;
 
     public static void overrideRestApi(RestApi restApi) {
         restApiOverride = restApi;
@@ -18,5 +20,24 @@ public class InstrumentationTestApplication extends ContestApplication {
 
     public static void clearRestApiOverride() {
         restApiOverride = null;
+    }
+
+    public static void overrideUserSettings(UserSettings userSettings) {
+        userSettingsOverride = userSettings;
+    }
+
+    public static void clearUserSettingsOverride() {
+        userSettingsOverride = null;
+    }
+
+    @Override
+    public PresenterConfiguration getPresenterConfiguration() {
+        return new PresenterConfiguration(
+                // using AsyncTask executor since Espresso automatically waits for it to clear before proceeding
+                Schedulers.from(AsyncTask.THREAD_POOL_EXECUTOR),
+                AndroidSchedulers.mainThread(),
+                userSettingsOverride != null ? userSettingsOverride : SharedPreferencesManager.getInstance(this),
+                restApiOverride != null ? restApiOverride : RetrofitClient.getApi()
+        );
     }
 }

--- a/app/src/androidTest/java/io/intrepid/contest/rest/TestRestClient.java
+++ b/app/src/androidTest/java/io/intrepid/contest/rest/TestRestClient.java
@@ -1,9 +1,0 @@
-package io.intrepid.contest.rest;
-
-import io.intrepid.contest.rules.MockServerRule;
-
-public class TestRestClient {
-    public static RestApi getRestApi(MockServerRule mockServer) {
-        return RetrofitClient.getTestApi(mockServer.getServerUrl());
-    }
-}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
           package="io.intrepid.contest"
     >
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <uses-feature
         android:name="android.hardware.camera"
         />

--- a/app/src/main/java/io/intrepid/contest/ContestApplication.java
+++ b/app/src/main/java/io/intrepid/contest/ContestApplication.java
@@ -4,6 +4,9 @@ import android.app.Application;
 
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.rest.RetrofitClient;
+import io.intrepid.contest.settings.SharedPreferencesManager;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 
@@ -13,6 +16,7 @@ public class ContestApplication extends Application {
     public void onCreate() {
         super.onCreate();
         Timber.plant(new Timber.DebugTree());
+        RetrofitClient.init(SharedPreferencesManager.getInstance(this));
         initCalligraphy();
     }
 
@@ -25,6 +29,11 @@ public class ContestApplication extends Application {
     }
 
     public PresenterConfiguration getPresenterConfiguration() {
-        return new PresenterConfiguration(RetrofitClient.getApi());
+        return new PresenterConfiguration(
+                Schedulers.io(),
+                AndroidSchedulers.mainThread(),
+                SharedPreferencesManager.getInstance(this),
+                RetrofitClient.getApi()
+        );
     }
 }

--- a/app/src/main/java/io/intrepid/contest/base/PresenterConfiguration.java
+++ b/app/src/main/java/io/intrepid/contest/base/PresenterConfiguration.java
@@ -3,17 +3,45 @@ package io.intrepid.contest.base;
 import android.support.annotation.NonNull;
 
 import io.intrepid.contest.rest.RestApi;
+import io.intrepid.contest.settings.UserSettings;
+import io.reactivex.Scheduler;
 
 /**
  * Wrapper class for common dependencies that all presenters are expected to have
  */
 public class PresenterConfiguration {
     @NonNull
+    private final Scheduler ioScheduler;
+    @NonNull
+    private final Scheduler uiScheduler;
+    @NonNull
+    private final UserSettings userSettings;
+    @NonNull
     private final RestApi restApi;
 
-
-    public PresenterConfiguration(@NonNull RestApi restApi) {
+    public PresenterConfiguration(@NonNull Scheduler ioScheduler,
+                                  @NonNull Scheduler uiScheduler,
+                                  @NonNull UserSettings userSettings,
+                                  @NonNull RestApi restApi) {
+        this.ioScheduler = ioScheduler;
+        this.uiScheduler = uiScheduler;
+        this.userSettings = userSettings;
         this.restApi = restApi;
+    }
+
+    @NonNull
+    public Scheduler getIoScheduler() {
+        return ioScheduler;
+    }
+
+    @NonNull
+    public Scheduler getUiScheduler() {
+        return uiScheduler;
+    }
+
+    @NonNull
+    public UserSettings getUserSettings() {
+        return userSettings;
     }
 
     @NonNull

--- a/app/src/main/java/io/intrepid/contest/customviews/HintLabelEditText.java
+++ b/app/src/main/java/io/intrepid/contest/customviews/HintLabelEditText.java
@@ -81,7 +81,7 @@ public class HintLabelEditText extends LinearLayout {
         editText.setError(error);
     }
 
-    public CharSequence getText() {
-        return editText.getText();
+    public String getText() {
+        return editText.getText().toString();
     }
 }

--- a/app/src/main/java/io/intrepid/contest/models/InvitationResponse.java
+++ b/app/src/main/java/io/intrepid/contest/models/InvitationResponse.java
@@ -1,0 +1,11 @@
+package io.intrepid.contest.models;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class InvitationResponse {
+    @Expose
+    public UUID id;
+}

--- a/app/src/main/java/io/intrepid/contest/rest/RestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RestApi.java
@@ -1,4 +1,11 @@
 package io.intrepid.contest.rest;
 
+import io.intrepid.contest.models.InvitationResponse;
+import io.reactivex.Observable;
+import retrofit2.http.PATCH;
+import retrofit2.http.Path;
+
 public interface RestApi {
+    @PATCH("invitations/{code}/redeem")
+    Observable<InvitationResponse> redeemInvitationCode(@Path("code") String code);
 }

--- a/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
@@ -1,43 +1,63 @@
 package io.intrepid.contest.rest;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.jakewharton.retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 
 import java.util.concurrent.TimeUnit;
 
 import io.intrepid.contest.BuildConfig;
+import io.intrepid.contest.settings.UserSettings;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 import timber.log.Timber;
 
 public class RetrofitClient {
 
-    // TODO: change this to a real endpoint
-    private static final String BASE_URL = "https://api.ipify.org/";
+    private static final String ACCEPT_APPLICATION = "vnd.judgy-server.herokuapp.com";
+    private static final String BASE_URL = "http://judgy-server.herokuapp.com/api/";
     private static final int CONNECTION_TIMEOUT = 30;
-
-    private static RestApi instance;
-
-    public static RestApi getApi() {
-        if (instance == null) {
-            instance = createRestApi(BASE_URL);
-        }
-        return instance;
-    }
-
-    @VisibleForTesting
-    static RestApi getTestApi(String baseUrl) {
-        return createRestApi(baseUrl);
-    }
+    private static final int API_VERSION = 1;
+    private static RestApi restApi;
 
     private RetrofitClient() {
     }
 
-    private static RestApi createRestApi(String baseUrl) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    public static void init(UserSettings userSettings) {
+        restApi = createRestApi(BASE_URL, userSettings);
+    }
+
+    public static RestApi getApi() {
+        return restApi;
+    }
+
+    @VisibleForTesting
+    static RestApi getTestApi(String baseUrl, @NonNull UserSettings userSettings) {
+        return createRestApi(baseUrl, userSettings);
+    }
+
+    private static RestApi createRestApi(String baseUrl, UserSettings userSettings) {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    Request request = chain.request().newBuilder()
+                            .addHeader("Authorization", "Token token=" + userSettings.getAuthenticationToken())
+                            .addHeader("Accept", "application/" + ACCEPT_APPLICATION +
+                                    "; version=" + String.valueOf(API_VERSION))
+                            .addHeader("Content-type", "application/json")
+                            .build();
+                    return chain.proceed(request);
+                });
         if (BuildConfig.LOG_CONSOLE) {
-            builder.addInterceptor(new HttpLoggingInterceptor(message -> Timber.v(message)).setLevel(HttpLoggingInterceptor.Level.BODY));
+            builder.addInterceptor(new HttpLoggingInterceptor(message -> Timber.v(message)).setLevel(
+                    HttpLoggingInterceptor.Level.BODY));
         }
         OkHttpClient httpClient = builder
                 .connectTimeout(CONNECTION_TIMEOUT, TimeUnit.SECONDS)
@@ -46,8 +66,17 @@ public class RetrofitClient {
         return new Retrofit.Builder()
                 .baseUrl(baseUrl)
                 .client(httpClient)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(getConverter())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .build()
                 .create(RestApi.class);
+    }
+
+    private static Converter.Factory getConverter() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+                .setPrettyPrinting()
+                .create();
+        return GsonConverterFactory.create(gson);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
@@ -51,7 +51,7 @@ public class NameContestFragment extends BaseFragment<NameContestPresenter> impl
 
     @Override
     public void onNextClicked() {
-        presenter.onContestNameUpdate(contestNameField.getText().toString());
+        presenter.onContestNameUpdate(contestNameField.getText());
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageActivity.java
@@ -170,7 +170,7 @@ public class EntryImageActivity extends BaseMvpActivity<EntryImageContract.Prese
 
         private final int value;
 
-        private RequestType(int value) {
+        RequestType(int value) {
             this.value = value;
         }
 

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageContract.java
@@ -4,7 +4,7 @@ import android.graphics.Bitmap;
 
 import io.intrepid.contest.base.BaseContract;
 
-public class EntryImageContract {
+class EntryImageContract {
     interface View extends BaseContract.View {
         String getEntryName();
 

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinActivity.java
@@ -4,14 +4,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
 import android.widget.Button;
+import android.widget.Toast;
 
 import butterknife.BindView;
 import butterknife.OnClick;
 import butterknife.OnTextChanged;
+import io.intrepid.contest.BuildConfig;
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BaseMvpActivity;
 import io.intrepid.contest.base.PresenterConfiguration;
+import io.intrepid.contest.customviews.HintLabelEditText;
 import io.intrepid.contest.screens.entrysubmission.entryname.EntryNameActivity;
 
 import static android.view.View.GONE;
@@ -21,6 +25,8 @@ public class JoinActivity extends BaseMvpActivity<JoinContract.Presenter> implem
 
     @BindView(R.id.enter_code_submit_button)
     Button enterCodeSubmitButton;
+    @BindView(R.id.enter_code_edit_view)
+    HintLabelEditText enterCodeEditView;
 
     public static Intent makeIntent(Context context) {
         return new Intent(context, JoinActivity.class);
@@ -52,7 +58,7 @@ public class JoinActivity extends BaseMvpActivity<JoinContract.Presenter> implem
 
     @OnClick(R.id.enter_code_submit_button)
     protected void onSubmitButtonClicked() {
-        presenter.onSubmitButtonClicked();
+        presenter.onSubmitButtonClicked(enterCodeEditView.getText());
     }
 
     @Override
@@ -68,5 +74,39 @@ public class JoinActivity extends BaseMvpActivity<JoinContract.Presenter> implem
     @Override
     public void showEntryNameScreen() {
         startActivity(EntryNameActivity.makeIntent(this));
+    }
+
+    @Override
+    public void showInvalidCodeErrorMessage() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(R.string.error_redeeming_code)
+                .setTitle(R.string.error_redeeming_code_title)
+                .setNeutralButton(R.string.common_ok, (dialog, id) -> {
+                });
+        builder.create().show();
+    }
+
+    @Override
+    public void showApiErrorMessage() {
+        Context context = getApplicationContext();
+        int duration = Toast.LENGTH_SHORT;
+        Toast toast = Toast.makeText(context, getResources().getString(R.string.error_api), duration);
+        toast.show();
+
+        if (BuildConfig.DEBUG) {
+            Thread thread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        Thread.sleep(duration);
+                        showEntryNameScreen();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+
+            thread.run();
+        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinContract.java
@@ -2,18 +2,22 @@ package io.intrepid.contest.screens.entrysubmission.join;
 
 import io.intrepid.contest.base.BaseContract;
 
-public class JoinContract {
+class JoinContract {
     interface View extends BaseContract.View {
         void showSubmitButton();
 
         void hideSubmitButton();
 
         void showEntryNameScreen();
+
+        void showInvalidCodeErrorMessage();
+
+        void showApiErrorMessage();
     }
 
     interface Presenter extends BaseContract.Presenter<View> {
         void onEntryCodeTextChanged(String newCode);
 
-        void onSubmitButtonClicked();
+        void onSubmitButtonClicked(String code);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinPresenter.java
@@ -4,6 +4,8 @@ import android.support.annotation.NonNull;
 
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.base.PresenterConfiguration;
+import io.intrepid.contest.models.InvitationResponse;
+import io.reactivex.disposables.Disposable;
 
 class JoinPresenter extends BasePresenter<JoinContract.View> implements JoinContract.Presenter {
 
@@ -21,7 +23,20 @@ class JoinPresenter extends BasePresenter<JoinContract.View> implements JoinCont
     }
 
     @Override
-    public void onSubmitButtonClicked() {
-        view.showEntryNameScreen();
+    public void onSubmitButtonClicked(String code) {
+        Disposable disposable = restApi.redeemInvitationCode(code)
+                .compose(subscribeOnIoObserveOnUi())
+                .subscribe(response -> showResult(response), throwable -> {
+                    view.showApiErrorMessage();
+                });
+        disposables.add(disposable);
+    }
+
+    private void showResult(InvitationResponse response) {
+        if (response.id != null) {
+            view.showEntryNameScreen();
+        } else {
+            view.showInvalidCodeErrorMessage();
+        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/splash/SplashPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/splash/SplashPresenter.java
@@ -7,9 +7,14 @@ import io.intrepid.contest.base.PresenterConfiguration;
 
 public class SplashPresenter extends BasePresenter<SplashContract.View> implements SplashContract.Presenter {
 
+    public static final String TEST_AUTHENTICATION_TOKEN = "503adec2-6b60-422d-9f94-3095af9c1416";
+
     public SplashPresenter(@NonNull SplashContract.View view,
                            @NonNull PresenterConfiguration configuration) {
         super(view, configuration);
+
+        // todo: set the authentication token when the app is downloaded, not here
+        userSettings.setAuthenticationToken(TEST_AUTHENTICATION_TOKEN);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/settings/SharedPreferencesManager.java
+++ b/app/src/main/java/io/intrepid/contest/settings/SharedPreferencesManager.java
@@ -1,0 +1,39 @@
+package io.intrepid.contest.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.annotation.VisibleForTesting;
+
+public class SharedPreferencesManager implements UserSettings {
+
+    private static final String AUTHENTICATION_TOKEN = "authentication_token";
+
+    private static SharedPreferencesManager instance;
+    private final SharedPreferences preferences;
+
+    private SharedPreferencesManager(Context context) {
+        this(PreferenceManager.getDefaultSharedPreferences(context));
+    }
+
+    private SharedPreferencesManager(SharedPreferences preferences) {
+        this.preferences = preferences;
+    }
+
+    public static UserSettings getInstance(Context context) {
+        if (instance == null) {
+            instance = new SharedPreferencesManager(context);
+        }
+        return instance;
+    }
+
+    @Override
+    public String getAuthenticationToken() {
+        return preferences.getString(AUTHENTICATION_TOKEN, "");
+    }
+
+    @Override
+    public void setAuthenticationToken(String authenticationToken) {
+        preferences.edit().putString(AUTHENTICATION_TOKEN, authenticationToken).apply();
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/settings/UserSettings.java
+++ b/app/src/main/java/io/intrepid/contest/settings/UserSettings.java
@@ -1,0 +1,7 @@
+package io.intrepid.contest.settings;
+
+public interface UserSettings {
+    String getAuthenticationToken();
+
+    void setAuthenticationToken(String authenticationToken);
+}

--- a/app/src/main/java/io/intrepid/contest/utils/RxUtils.java
+++ b/app/src/main/java/io/intrepid/contest/utils/RxUtils.java
@@ -1,0 +1,13 @@
+package io.intrepid.contest.utils;
+
+import android.support.annotation.Nullable;
+
+import io.reactivex.disposables.Disposable;
+
+class RxUtils {
+    static void unsubscribeDisposable(@Nullable Disposable disposable) {
+        if (disposable != null) {
+            disposable.dispose();
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,10 @@
     <string name="create_contest">Create Contest</string>
     <string name="create_join_prompt">Create and join contests</string>
     <string name="contestant_welcome_message">Welcome!</string>
+
     <string name="join_contest_bar_title">Join %1$s</string>
+    <string name="error_redeeming_code">Unfortunately this code could not be redeemed. \\nPlease confirm the code and try again.</string>
+    <string name="error_redeeming_code_title">Error</string>
     <string name="name_entry">Name your submission</string>
     <string name="entry_image_bar_title">Submit Image</string>
     <string name="entry_image_question">Add an image for \n%1$s?</string>
@@ -30,9 +33,10 @@
     <string name="scoring_categories">Scoring Categories</string>
     <string name="category_name">Category Name</string>
     <string name="description_optional">Description (optional)</string>
-    <string name="error_msg">Error</string>
     <string name="category_name_example">Example Category</string>
     <string name="category_description_example">This is an example</string>
     <string name="trophy">Trophy</string>
     <string name="add_a_category">Add a category</string>
+
+    <string name="error_api">Error communicating with the API</string>
 </resources>

--- a/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
@@ -15,10 +15,8 @@ import io.intrepid.contest.testutils.BasePresenterTest;
 import io.intrepid.contest.testutils.TestPresenterConfiguration;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/app/src/test/java/io/intrepid/contest/testutils/BasePresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/testutils/BasePresenterTest.java
@@ -1,5 +1,6 @@
 package io.intrepid.contest.testutils;
 
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.mockito.junit.MockitoJUnit;
@@ -7,6 +8,8 @@ import org.mockito.junit.MockitoRule;
 
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.rest.RestApi;
+import io.intrepid.contest.settings.UserSettings;
+import io.reactivex.schedulers.TestScheduler;
 
 public class BasePresenterTest<P extends BasePresenter> {
     @Rule
@@ -14,11 +17,17 @@ public class BasePresenterTest<P extends BasePresenter> {
 
     protected P presenter;
     protected TestPresenterConfiguration testConfiguration;
+    private TestScheduler ioScheduler;
+    private TestScheduler uiScheduler;
     protected RestApi mockRestApi;
+    private UserSettings mockUserSettings;
 
     @Before
     public void baseSetup() {
         testConfiguration = TestPresenterConfiguration.createTestConfiguration();
+        ioScheduler = testConfiguration.getIoScheduler();
+        uiScheduler = testConfiguration.getUiScheduler();
         mockRestApi = testConfiguration.getRestApi();
+        mockUserSettings = testConfiguration.getUserSettings();
     }
 }

--- a/app/src/test/java/io/intrepid/contest/testutils/TestPresenterConfiguration.java
+++ b/app/src/test/java/io/intrepid/contest/testutils/TestPresenterConfiguration.java
@@ -6,15 +6,43 @@ import org.mockito.Mockito;
 
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.rest.RestApi;
+import io.intrepid.contest.settings.UserSettings;
+import io.reactivex.schedulers.TestScheduler;
 
 @SuppressWarnings("WeakerAccess")
 public class TestPresenterConfiguration extends PresenterConfiguration {
-    public static TestPresenterConfiguration createTestConfiguration() {
-        RestApi mockApi = Mockito.mock(RestApi.class);
-        return new TestPresenterConfiguration(mockApi);
+    public TestPresenterConfiguration(@NonNull UserSettings userSettings,
+                                      @NonNull RestApi restApi) {
+        super(new TestScheduler(), new TestScheduler(), userSettings, restApi);
     }
 
-    public TestPresenterConfiguration(@NonNull RestApi restApi) {
-        super(restApi);
+    public static TestPresenterConfiguration createTestConfiguration() {
+        RestApi mockApi = Mockito.mock(RestApi.class);
+        UserSettings mockSettings = Mockito.mock(UserSettings.class);
+        return new TestPresenterConfiguration(
+                mockSettings,
+                mockApi
+        );
+    }
+
+    @NonNull
+    @Override
+    public TestScheduler getIoScheduler() {
+        return (TestScheduler) super.getIoScheduler();
+    }
+
+    @NonNull
+    @Override
+    public TestScheduler getUiScheduler() {
+        return (TestScheduler) super.getUiScheduler();
+    }
+
+    /**
+     * Helper method for triggering pending Rx events
+     */
+    public void triggerRxSchedulers() {
+        getIoScheduler().triggerActions();
+        getUiScheduler().triggerActions();
     }
 }
+

--- a/app/src/test/java/io/intrepid/contest/utils/RxUtilsTest.java
+++ b/app/src/test/java/io/intrepid/contest/utils/RxUtilsTest.java
@@ -1,0 +1,21 @@
+package io.intrepid.contest.utils;
+
+import org.junit.Test;
+
+import io.reactivex.disposables.Disposable;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class RxUtilsTest {
+
+    @Test
+    public void unsubscribeDisposable() throws Exception {
+        Disposable mockDisposable = mock(Disposable.class);
+        RxUtils.unsubscribeDisposable(mockDisposable);
+        verify(mockDisposable).dispose();
+
+        // just ensures that there's not exception
+        RxUtils.unsubscribeDisposable(null);
+    }
+}


### PR DESCRIPTION
This PR touches many files from the Skeleton, but I haven't come up with any new code myself: I copied it all either from [Skeleton](https://github.com/IntrepidPursuits/AndroidSkeleton) itself, or from [Northeastern](https://github.com/IntrepidPursuits/northeastern-isle-android) (which also uses some version of Skeleton)

- The API endpoint I'm using is not live yet, so I receive a 404 error when it's called. For that I added a [toast](https://github.com/IntrepidPursuits/ContestAndroid/compare/master...gabi/mock-api#diff-9420d6573f9d9b3821adfe82b919922bR89) that, in debug mode, also takes the user to the next screen so we're not stuck there.

- I am not using [`TestConfig`](https://github.com/IntrepidPursuits/ContestAndroid/blob/gabi/mock-api/app/src/main/java/io/intrepid/contest/TestConfig.java), I saw in skeleton how they used a `PreferencesManager` and opted to [set that up](https://github.com/IntrepidPursuits/ContestAndroid/compare/master...gabi/mock-api#diff-246713380416f8f3675388ad5cf4738cR15). In the future both will go away I believe, we just can't forget them.