### PR TITLE
Add back button to activities

### DIFF
--- a/app/src/main/java/io/intrepid/contest/base/BaseActivity.java
+++ b/app/src/main/java/io/intrepid/contest/base/BaseActivity.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
 
 import butterknife.ButterKnife;
 import io.intrepid.contest.ContestApplication;
@@ -16,6 +17,8 @@ import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
 
 abstract class BaseActivity extends AppCompatActivity {
 
+    private ActionBar actionBar;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         Timber.v("Lifecycle onCreate: " + this);
@@ -23,6 +26,8 @@ abstract class BaseActivity extends AppCompatActivity {
 
         setContentView(getLayoutResourceId());
         ButterKnife.bind(this);
+
+        actionBar = getSupportActionBar();
     }
 
     @Override
@@ -87,13 +92,28 @@ abstract class BaseActivity extends AppCompatActivity {
     }
 
     protected void setActionBarTitle(String title) {
-        ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            getSupportActionBar().setTitle(title);
+            actionBar.setTitle(title);
         }
     }
 
     protected void setActionBarTitle(@StringRes int titleResource) {
         setActionBarTitle(getResources().getString(titleResource));
+    }
+
+    protected void setActionBarDisplayHomeAsUpEnabled(boolean enabled) {
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(enabled);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageActivity.java
@@ -67,6 +67,7 @@ public class EntryImageActivity extends BaseMvpActivity<EntryImageContract.Prese
         }
 
         setActionBarTitle(getResources().getString(R.string.entry_image_bar_title));
+        setActionBarDisplayHomeAsUpEnabled(true);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryname/EntryNameActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryname/EntryNameActivity.java
@@ -48,6 +48,7 @@ public class EntryNameActivity extends BaseMvpActivity<EntryNameContract.Present
         super.onViewCreated(savedInstanceState);
 
         setActionBarTitle(R.string.contestant_welcome_message);
+        setActionBarDisplayHomeAsUpEnabled(true);
     }
 
     @OnTextChanged(R.id.hint_label_edit_text)

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/join/JoinActivity.java
@@ -42,6 +42,7 @@ public class JoinActivity extends BaseMvpActivity<JoinContract.Presenter> implem
         super.onViewCreated(savedInstanceState);
 
         setActionBarTitle(getResources().getString(R.string.join_contest_bar_title, "Chili Cookoff"));
+        setActionBarDisplayHomeAsUpEnabled(true);
     }
 
     @OnTextChanged(R.id.hint_label_edit_text)


### PR DESCRIPTION
Another tiny PR just to add back button in the action bar.

Even though I have set up the behavior of the button in the `BaseActivity`, I have not enabled it by default in the views, because some screens don't have it or have a different button (e.g. a cross to close).

Also the behavior I set up is the same as pressing the back button, because I imagine that the `EntryNameActivity` can be started both after Joining a contest and after Reopening a contest you have already joined.