### PR TITLE
bug fix init

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestActivity.java
@@ -80,9 +80,9 @@ public class NewContestActivity extends BaseMvpActivity<NewContestPresenter> imp
     }
 
     private void setupViewPager(Contest.Builder contest) {
-        if(tabAdapter == null) {
+        if (tabAdapter == null) {
             tabAdapter = new SlidingTabAdapter(this);
-        }else{
+        } else {
             tabAdapter.clear();
         }
         tabAdapter.addFragment(NameContestFragment.newInstance(contest));
@@ -118,9 +118,11 @@ public class NewContestActivity extends BaseMvpActivity<NewContestPresenter> imp
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {
             case NOTIFY_NEW_CATEGORY:
-                String categoryName = data.getStringExtra(CATEGORY_NAME);
-                String categoryDescription = data.getStringExtra(CATEGORY_DESCRIPTION);
-                presenter.onNewCategoryAdded(categoryName, categoryDescription);
+                if (resultCode == RESULT_OK && data != null) {
+                    String categoryName = data.getStringExtra(CATEGORY_NAME);
+                    String categoryDescription = data.getStringExtra(CATEGORY_DESCRIPTION);
+                    presenter.onNewCategoryAdded(categoryName, categoryDescription);
+                }
                 break;
         }
     }


### PR DESCRIPTION
Small bug fix related to navigating back without actually entering a new category.

The bug can currently be reproduced by clicking the Add Category fab button and then hitting the back key button on the Android device. 