### PR TITLE
CON-149: Refactor API mocks

### DIFF
--- a/app/src/main/java/io/intrepid/contest/ContestApplication.java
+++ b/app/src/main/java/io/intrepid/contest/ContestApplication.java
@@ -33,7 +33,7 @@ public class ContestApplication extends Application {
                 Schedulers.io(),
                 AndroidSchedulers.mainThread(),
                 SharedPreferencesManager.getInstance(this),
-                RetrofitClient.getApi()
+                RetrofitClient.getMockApi()
         );
     }
 }

--- a/app/src/main/java/io/intrepid/contest/rest/ContestStatusResponse.java
+++ b/app/src/main/java/io/intrepid/contest/rest/ContestStatusResponse.java
@@ -1,6 +1,39 @@
 package io.intrepid.contest.rest;
 
 public class ContestStatusResponse {
-    public boolean waitingForSubmissions;
-    public int numSubmissionsMissing;
+    private boolean submissionsEnded;
+    private int entriesSubmitted;
+    private int totalEntries;
+
+    private boolean contestEnded;
+    private int judgesSubmitted;
+    private int totalJudges;
+
+    public void setSubmissionData(boolean submissionsEnded, int entriesSubmitted, int totalEntries) {
+        this.submissionsEnded = submissionsEnded;
+        this.entriesSubmitted = entriesSubmitted;
+        this.totalEntries = totalEntries;
+    }
+
+    public void setJudgeData(boolean contestEnded, int judgesSubmitted, int totalJudges) {
+        this.contestEnded = contestEnded;
+        this.judgesSubmitted = judgesSubmitted;
+        this.totalJudges = totalJudges;
+    }
+
+    public int getNumSubmissionsMissing() {
+        return totalEntries - entriesSubmitted;
+    }
+
+    public int getNumScoresMissing() {
+        return totalJudges - judgesSubmitted;
+    }
+
+    public boolean haveSubmissionsEnded() {
+        return submissionsEnded;
+    }
+
+    public boolean hasContestEnded() {
+        return contestEnded;
+    }
 }

--- a/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
@@ -1,0 +1,123 @@
+package io.intrepid.contest.rest;
+
+import android.support.annotation.NonNull;
+
+import java.util.UUID;
+
+import io.intrepid.contest.models.Contest;
+import io.intrepid.contest.models.Entry;
+import io.intrepid.contest.models.Participant;
+import io.intrepid.contest.models.ParticipationType;
+import io.intrepid.contest.models.User;
+import io.reactivex.Observable;
+import retrofit2.http.Body;
+import retrofit2.http.Path;
+
+import static io.reactivex.Observable.error;
+
+public class MockRestApi implements RestApi {
+    public static final String TEST_JUDGE_CODE = "judge";
+
+    private final UUID userId;
+    private UUID contestId;
+    private String contestTitle;
+    private int numGetContestStatusCallsForParticipant;
+
+    public MockRestApi() {
+        userId = UUID.randomUUID();
+        contestId = UUID.randomUUID();
+        contestTitle = "Contest title";
+        numGetContestStatusCallsForParticipant = 0;
+    }
+
+    @NonNull
+    private UserCreationResponse getValidUserCreationResponse() {
+        UserCreationResponse userCreationResponse = new UserCreationResponse();
+        userCreationResponse.user = new User();
+        userCreationResponse.user.setId(userId);
+        return userCreationResponse;
+    }
+
+    @Override
+    public Observable<UserCreationResponse> createUser() {
+        return Observable.just(getValidUserCreationResponse());
+    }
+
+    @NonNull
+    private RedeemInvitationResponse getValidRedeemInvitationResponse(ParticipationType participationType) {
+        RedeemInvitationResponse redeemInvitationResponse = new RedeemInvitationResponse();
+        redeemInvitationResponse.participant = new Participant();
+        redeemInvitationResponse.participant.setContestId(contestId);
+        redeemInvitationResponse.participant.setParticipationType(participationType);
+        return redeemInvitationResponse;
+    }
+
+    @Override
+    public Observable<RedeemInvitationResponse> redeemInvitationCode(@Path("code") String code,
+                                                                     @Body RedeemInvitationRequest redeemInvitationRequest) {
+        if (contestId == null) {
+            return Observable.error(new Throwable());
+        }
+
+        // Participant changed
+        numGetContestStatusCallsForParticipant = 0;
+
+        if (code.equals(TEST_JUDGE_CODE)) {
+            return Observable.just(getValidRedeemInvitationResponse(ParticipationType.JUDGE));
+        }
+        return Observable.just(getValidRedeemInvitationResponse(ParticipationType.CONTESTANT));
+    }
+
+    @NonNull
+    private EntryResponse getValidEntryResponse() {
+        Entry entry = new Entry();
+        entry.id = UUID.randomUUID();
+        EntryResponse entryResponse = new EntryResponse();
+        entryResponse.setEntry(entry);
+        return entryResponse;
+    }
+
+    @Override
+    public Observable<EntryResponse> createEntry(@Path("contestId") String contestId, @Body EntryRequest entryRequest) {
+        return Observable.just(getValidEntryResponse());
+    }
+
+    @NonNull
+    private ContestStatusResponse getValidEntryResponseWaitingForSubmissions() {
+        ContestStatusResponse response = new ContestStatusResponse();
+        response.setSubmissionData(false, 5, 10);
+        response.setJudgeData(false, 0, 6);
+        return response;
+    }
+
+    @NonNull
+    private ContestStatusResponse getValidEntryResponseWaitingForScores() {
+        ContestStatusResponse response = new ContestStatusResponse();
+        response.setSubmissionData(true, 10, 10);
+        response.setJudgeData(false, 2, 6);
+        return response;
+    }
+
+    @Override
+    public Observable<ContestStatusResponse> getContestStatus(@Path("contestId") String contestId) {
+        numGetContestStatusCallsForParticipant++;
+
+        if (numGetContestStatusCallsForParticipant == 1) {
+            return Observable.just(getValidEntryResponseWaitingForSubmissions());
+        }
+        return Observable.just(getValidEntryResponseWaitingForScores());
+    }
+
+    @NonNull
+    private ContestResponse getValidContestResponse() {
+        ContestResponse response = new ContestResponse();
+        response.contest = new Contest();
+        response.contest.setTitle(contestTitle);
+        return response;
+    }
+
+    @Override
+    public Observable<ContestResponse> getContestDetails(@Path("contestId") String contestId) {
+        return Observable.just(getValidContestResponse());
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/rest/RestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RestApi.java
@@ -9,7 +9,7 @@ import retrofit2.http.Path;
 
 public interface RestApi {
     @POST("users")
-    Observable<UserCreationRequest> createUser();
+    Observable<UserCreationResponse> createUser();
 
     @PATCH("invitations/{code}/redeem")
     Observable<RedeemInvitationResponse> redeemInvitationCode(@Path("code") String code,

--- a/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
@@ -24,12 +24,14 @@ public class RetrofitClient {
     private static final int CONNECTION_TIMEOUT = 30;
     private static final int API_VERSION = 1;
     private static RestApi restApi;
+    private static RestApi mockRestApi;
 
     private RetrofitClient() {
     }
 
     public static void init(PersistentSettings persistentSettings) {
         restApi = createRestApi(BASE_URL, persistentSettings);
+        mockRestApi = createMockRestApi();
     }
 
     public static RestApi getApi() {
@@ -70,5 +72,13 @@ public class RetrofitClient {
                 .setPrettyPrinting()
                 .create();
         return GsonConverterFactory.create(gson);
+    }
+
+    private static RestApi createMockRestApi() {
+        return new MockRestApi();
+    }
+
+    public static RestApi getMockApi() {
+        return mockRestApi;
     }
 }

--- a/app/src/main/java/io/intrepid/contest/rest/UserCreationResponse.java
+++ b/app/src/main/java/io/intrepid/contest/rest/UserCreationResponse.java
@@ -2,6 +2,6 @@ package io.intrepid.contest.rest;
 
 import io.intrepid.contest.models.User;
 
-public class UserCreationRequest {
+public class UserCreationResponse {
     public User user;
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestoverview/ContestOverviewActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestoverview/ContestOverviewActivity.java
@@ -45,9 +45,9 @@ public class ContestOverviewActivity extends BaseMvpActivity<ContestOverviewCont
     }
 
     @Override
-    public void showNumSubmissionsMissing(int numSubmissionsMissing) {
+    public void showNumSubmissionsWaiting(int numSubmissionsWaiting) {
         String submissions = getResources()
-                .getQuantityString(R.plurals.numberOfSubmissions, numSubmissionsMissing, numSubmissionsMissing);
+                .getQuantityString(R.plurals.numberOfSubmissions, numSubmissionsWaiting, numSubmissionsWaiting);
         introTextView.setText(
                 getResources().getString(R.string.contest_overview_intro, submissions));
     }

--- a/app/src/main/java/io/intrepid/contest/screens/contestoverview/ContestOverviewContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestoverview/ContestOverviewContract.java
@@ -6,7 +6,7 @@ class ContestOverviewContract {
     interface View extends BaseContract.View {
         void showContestName(String contestName);
 
-        void showNumSubmissionsMissing(int numSubmissionsMissing);
+        void showNumSubmissionsWaiting(int numSubmissionsWaiting);
     }
 
     interface Presenter extends BaseContract.Presenter<View> {

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusActivity.java
@@ -5,10 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
-import android.widget.Button;
 
-import butterknife.BindView;
-import butterknife.OnClick;
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BaseMvpActivity;
 import io.intrepid.contest.base.PresenterConfiguration;
@@ -20,12 +17,8 @@ import io.intrepid.contest.screens.splash.SplashActivity;
 import io.reactivex.functions.Consumer;
 import timber.log.Timber;
 
-import static android.view.View.GONE;
-
 public class ContestStatusActivity extends BaseMvpActivity<ContestStatusContract.Presenter>
         implements ContestStatusContract.View, ContestStatusActivityContract {
-    @BindView(R.id.temporary_skip_button)
-    Button temporarySkipButton;
 
     public static Intent makeIntent(Context context) {
         return new Intent(context, ContestStatusActivity.class);
@@ -84,13 +77,6 @@ public class ContestStatusActivity extends BaseMvpActivity<ContestStatusContract
         }
 
         replaceFragment(fragment);
-    }
-
-    @OnClick(R.id.temporary_skip_button)
-    public void onTemporarySkipButtonClicked() {
-        // TODO: once API endpoing works, remove this button and actions triggered by it
-        presenter.onTemporarySkipButtonClicked();
-        temporarySkipButton.setVisibility(GONE);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusContract.java
@@ -14,8 +14,6 @@ class ContestStatusContract {
     }
 
     interface Presenter extends BaseContract.Presenter<View> {
-        void onTemporarySkipButtonClicked();
-
         void requestContestDetails(Consumer<ContestResponse> responseCallback, Consumer<Throwable> throwableCallback);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailablePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailablePresenter.java
@@ -33,11 +33,7 @@ public class ResultsAvailablePresenter extends BasePresenter<ResultsAvailableCon
     private Consumer<Throwable> onContestDetailsError() {
         return throwable -> {
             Timber.d("API error retrieving contest details: " + throwable.getMessage());
-
             view.showMessage(R.string.error_api);
-
-            // TODO: remove this fallback once API works
-            view.showContestName("Chili cookoff");
         };
     }
 

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/waitingsubmissions/WaitingSubmissionsPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/waitingsubmissions/WaitingSubmissionsPresenter.java
@@ -37,11 +37,7 @@ class WaitingSubmissionsPresenter extends BasePresenter<WaitingSubmissionsContra
     private Consumer<Throwable> onContestDetailsError() {
         return throwable -> {
             Timber.d("API error retrieving contest details: " + throwable.getMessage());
-
             view.showMessage(R.string.error_api);
-
-            // TODO: remove this fallback once API works
-            view.showContestName("Chili Cookoff");
         };
     }
 

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
@@ -53,10 +53,7 @@ class EntryImagePresenter extends BasePresenter<EntryImageContract.View> impleme
                 .compose(subscribeOnIoObserveOnUi())
                 .subscribe(response -> showResult(response), throwable -> {
                     Timber.d("API error creating an entry: " + throwable.getMessage());
-
-                    // TODO: once API endpoing works, stop showing message and skipping to next screen
                     view.showMessage(R.string.error_api);
-                    view.showContestStatusScreen();
                 });
         disposables.add(disposable);
     }

--- a/app/src/main/java/io/intrepid/contest/screens/join/JoinPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/join/JoinPresenter.java
@@ -2,13 +2,9 @@ package io.intrepid.contest.screens.join;
 
 import android.support.annotation.NonNull;
 
-import java.util.UUID;
-
-import io.intrepid.contest.BuildConfig;
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.base.PresenterConfiguration;
-import io.intrepid.contest.models.Participant;
 import io.intrepid.contest.models.ParticipationType;
 import io.intrepid.contest.rest.RedeemInvitationRequest;
 import io.intrepid.contest.rest.RedeemInvitationResponse;
@@ -16,8 +12,6 @@ import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
 class JoinPresenter extends BasePresenter<JoinContract.View> implements JoinContract.Presenter {
-
-    public static final String TEMPORARY_JUDGE_CODE = "judge";
 
     JoinPresenter(@NonNull JoinContract.View view, @NonNull PresenterConfiguration configuration) {
         super(view, configuration);
@@ -40,30 +34,9 @@ class JoinPresenter extends BasePresenter<JoinContract.View> implements JoinCont
                 .compose(subscribeOnIoObserveOnUi())
                 .subscribe(response -> showResult(response), throwable -> {
                     Timber.d("API error redeeming invitation code: " + throwable.getMessage());
-
-                    // TODO: remove creation of fake contest once API endpoint works
-                    if (BuildConfig.DEBUG) {
-                        persistentSettings.setCurrentContestId(UUID.randomUUID());
-                    }
-
-                    // TODO: once API endpoing works, stop showing message and skipping to next screen
                     view.showMessage(R.string.error_api);
-                    temporarySkipToNextScreen(code);
                 });
         disposables.add(disposable);
-    }
-
-    private void temporarySkipToNextScreen(String code) {
-        // TODO: once API endpoing works, stop showing message and skipping to next screen
-        RedeemInvitationResponse response = new RedeemInvitationResponse();
-        response.participant = new Participant();
-        response.participant.setContestId(UUID.randomUUID());
-        if (code.equals(TEMPORARY_JUDGE_CODE)) {
-            response.participant.setParticipationType(ParticipationType.JUDGE);
-        } else {
-            response.participant.setParticipationType(ParticipationType.CONTESTANT);
-        }
-        showResult(response);
     }
 
     private void showResult(RedeemInvitationResponse response) {

--- a/app/src/main/res/layout/activity_contest_status.xml
+++ b/app/src/main/res/layout/activity_contest_status.xml
@@ -4,17 +4,4 @@
     android:id="@+id/fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    >
-
-    <Button
-        android:id="@+id/temporary_skip_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:layout_marginTop="@dimen/activity_horizontal_margin"
-        android:backgroundTint="@android:color/white"
-        android:text="@string/common_ok"
-        android:textColor="@color/colorAccent"
-        />
-
-</FrameLayout>
+    />

--- a/app/src/test/java/io/intrepid/contest/screens/contestoverview/ContestOverviewPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestoverview/ContestOverviewPresenterTest.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.rest.ContestResponse;
-import io.intrepid.contest.rest.ContestStatusResponse;
 import io.intrepid.contest.screens.contestoverview.ContestOverviewContract.Presenter;
 import io.intrepid.contest.screens.contestoverview.ContestOverviewContract.View;
 import io.intrepid.contest.testutils.BasePresenterTest;
@@ -35,12 +34,6 @@ public class ContestOverviewPresenterTest extends BasePresenterTest<ContestOverv
         presenter = new ContestOverviewPresenter(mockView, testConfiguration);
 
         when(mockPersistentSettings.getCurrentContestId()).thenReturn(UUID.randomUUID());
-        initialSetupOfOnViewCreatedApiCalls();
-    }
-
-    private void initialSetupOfOnViewCreatedApiCalls() {
-        setupSuccessfulContestDetailsCall();
-        setupSuccessfulContestStatusCall();
     }
 
     private void setupSuccessfulContestDetailsCall() {
@@ -54,16 +47,6 @@ public class ContestOverviewPresenterTest extends BasePresenterTest<ContestOverv
         when(mockRestApi.getContestDetails(any())).thenReturn(error(new Throwable()));
     }
 
-    private void setupSuccessfulContestStatusCall() {
-        ContestStatusResponse response = new ContestStatusResponse();
-        response.numSubmissionsMissing = 5;
-        when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
-    }
-
-    private void setupFailedContestStatusCall() {
-        when(mockRestApi.getContestStatus(any())).thenReturn(error(new Throwable()));
-    }
-
     @Test
     public void onViewCreatedShouldShowContestNameWhenSuccessfullyRetrievedContestDetails() throws Exception {
         setupSuccessfulContestDetailsCall();
@@ -75,28 +58,8 @@ public class ContestOverviewPresenterTest extends BasePresenterTest<ContestOverv
     }
 
     @Test
-    public void onViewCreatedShouldShowNumSubmissionsMissingWhenSuccessfullyRetrievedContestStatus() throws Exception {
-        setupSuccessfulContestStatusCall();
-
-        presenter.onViewCreated();
-        testConfiguration.triggerRxSchedulers();
-
-        verify(mockView).showNumSubmissionsMissing(any(int.class));
-    }
-
-    @Test
     public void onViewCreatedShouldShowApiErrorMessageWhenContestDetailsCallThrowsError() throws Exception {
         setupFailedContestDetailsCall();
-
-        presenter.onViewCreated();
-        testConfiguration.triggerRxSchedulers();
-
-        verify(mockView).showMessage(any(int.class));
-    }
-
-    @Test
-    public void onViewCreatedShouldShowApiErrorMessageWhenContestStatusCallThrowsError() throws Exception {
-        setupFailedContestStatusCall();
 
         presenter.onViewCreated();
         testConfiguration.triggerRxSchedulers();

--- a/app/src/test/java/io/intrepid/contest/screens/join/JoinPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/join/JoinPresenterTest.java
@@ -108,14 +108,4 @@ public class JoinPresenterTest extends BasePresenterTest<JoinPresenter> {
 
         verify(mockView).showMessage(any(int.class));
     }
-
-    @Test
-    public void onSubmitButtonClickedShouldShowApiErrorMessageWhenApiCallThrowsErrorForJudgeCode() throws HttpException {
-        when(mockRestApi.redeemInvitationCode(any(), any())).thenReturn(error(throwable));
-
-        presenter.onSubmitButtonClicked("judge");
-        testConfiguration.triggerRxSchedulers();
-
-        verify(mockView).showMessage(any(int.class));
-    }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/splash/SplashPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/splash/SplashPresenterTest.java
@@ -1,5 +1,7 @@
 package io.intrepid.contest.screens.splash;
 
+import com.jakewharton.retrofit2.adapter.rxjava2.HttpException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,13 +12,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.UUID;
 
 import io.intrepid.contest.models.User;
-import io.intrepid.contest.rest.UserCreationRequest;
+import io.intrepid.contest.rest.UserCreationResponse;
 import io.intrepid.contest.testutils.BasePresenterTest;
 import io.reactivex.Observable;
 
 import static io.reactivex.Observable.error;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,10 +34,10 @@ public class SplashPresenterTest extends BasePresenterTest<SplashPresenter> {
     }
 
     private void setupSuccessfulUserCreation() {
-        UserCreationRequest userCreationRequest = new UserCreationRequest();
-        userCreationRequest.user = new User();
-        userCreationRequest.user.setId(UUID.randomUUID());
-        when(mockRestApi.createUser()).thenReturn(Observable.just(userCreationRequest));
+        UserCreationResponse UserCreationResponse = new UserCreationResponse();
+        UserCreationResponse.user = new User();
+        UserCreationResponse.user.setId(UUID.randomUUID());
+        when(mockRestApi.createUser()).thenReturn(Observable.just(UserCreationResponse));
     }
 
     private void setupFailedUserCreation() {
@@ -61,14 +62,13 @@ public class SplashPresenterTest extends BasePresenterTest<SplashPresenter> {
     }
 
     @Test
-    public void onViewCreatedShouldShowUserButtonsWhenUserCreationThrowsError() {
+    public void onViewCreatedShouldShowApiErrorMessageWhenApiCallThrowsError() throws HttpException {
         setupFailedUserCreation();
 
         splashPresenter.onViewCreated();
         testConfiguration.triggerRxSchedulers();
 
         verify(mockView).showMessage(any(int.class));
-        verify(mockView, never()).showUserButtons();
     }
 
     @Test


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-149

PART 2
Please look only at last commit: https://github.com/IntrepidPursuits/ContestAndroid/pull/39/commits/f046a8ff82e7f32443e49cd2e2f6b08996b7e596
- Update API endpoint according to web team's changes (PR waiting for approval)
- Update logic to handle that change, and also come back with logic to display `ContestOverview` for judges (that was hardcoded in the OK button, and the logic was not updated to do the same after the timer runs, so it was never displayed)
- Undo misunderstanding about data in `ContestOverviewActivity`. I had understood that the number displayed in the screen (https://zpl.io/HLz5o) was submissions waiting to be sent by contestants. Obviously that was a mistake, the number is actually submissions waiting to be scored by this particular judge user. The scoring is not implemented yet, so that number is just a constant for now and should be updated when that story comes.
Note to @abassawo : You might have conflicts in the `ContestOverviewPresenter.onViewCreated` when you rebase the branch where you're working with this file. Let me know if you have any doubts.

PART 1 (reviewed and approved)
- Create a `MockRestApi` class that concentrates all the mock code
- Remove TODOs "when the API is ready" from code
- Rename `UserCreationRequest` to `UserCreationResponse` (that's what it actually is)