### PR TITLE
Add OnPageChangeListener - Fix nav flow error

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
@@ -3,6 +3,5 @@ package io.intrepid.contest.screens.contestcreation;
 public interface ContestCreationFragment{
 
     void onNextClicked();
-
     void onFocus();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
@@ -3,4 +3,6 @@ package io.intrepid.contest.screens.contestcreation;
 public interface ContestCreationFragment{
 
     void onNextClicked();
+
+    void onFocus();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestActivity.java
@@ -54,6 +54,7 @@ public class NewContestActivity extends BaseMvpActivity<NewContestPresenter> imp
             actionBar.setDisplayHomeAsUpEnabled(true);
             setActionBarTitle(R.string.new_contest);
         }
+        viewPager.addOnPageChangeListener(presenter);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -1,6 +1,7 @@
 package io.intrepid.contest.screens.contestcreation;
 
 import android.support.annotation.NonNull;
+import android.support.v4.view.ViewPager;
 
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BasePresenter;
@@ -11,7 +12,7 @@ import io.intrepid.contest.rest.ContestWrapper;
 import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
-class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> implements NewContestMvpContract.Presenter {
+class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> implements NewContestMvpContract.Presenter, ViewPager.OnPageChangeListener {
     private Contest.Builder contest;
 
     NewContestPresenter(@NonNull NewContestMvpContract.View view,
@@ -88,5 +89,22 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
 
     private void onApiResult(ContestWrapper response) {
         view.showMessage(response.contest.toString() + " was created ");
+    }
+
+    @Override
+    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+        onPageSelected(position);
+    }
+
+    @Override
+    public void onPageSelected(int position) {
+        ContestCreationFragment fragment = view.getChildEditFragment(position);
+        fragment.onFocus();
+    }
+
+    @Override
+    public void onPageScrollStateChanged(int state) {
+        int position = view.getCurrentIndex();
+        onPageSelected(position);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
@@ -14,7 +14,6 @@ import io.intrepid.contest.base.BaseFragment;
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.models.Category;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
-import io.intrepid.contest.screens.contestcreation.EditContestContract;
 
 public class AddCategoriesFragment extends BaseFragment<AddCategoriesPresenter> implements AddCategoriesContract.View, ContestCreationFragment {
     @BindView(R.id.category_name_edittext)
@@ -67,7 +66,7 @@ public class AddCategoriesFragment extends BaseFragment<AddCategoriesPresenter> 
 
     @Override
     public void onFocus() {
-
+        //Do nothing - Intentional
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
@@ -14,6 +14,7 @@ import io.intrepid.contest.base.BaseFragment;
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.models.Category;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
+import io.intrepid.contest.screens.contestcreation.EditContestContract;
 
 public class AddCategoriesFragment extends BaseFragment<AddCategoriesPresenter> implements AddCategoriesContract.View, ContestCreationFragment {
     @BindView(R.id.category_name_edittext)

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/addcategoriestocontest/AddCategoriesFragment.java
@@ -65,6 +65,11 @@ public class AddCategoriesFragment extends BaseFragment<AddCategoriesPresenter> 
     }
 
     @Override
+    public void onFocus() {
+
+    }
+
+    @Override
     public void addCategory(Category category) {
         activity.addCategory(category);
     }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -18,7 +18,6 @@ import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 import io.intrepid.contest.screens.contestcreation.EditContestContract;
-import io.intrepid.contest.screens.contestcreation.addcategoriestocontest.AddCategoryActivity;
 import io.intrepid.contest.utils.dragdrop.SimpleItemTouchHelperCallback;
 
 
@@ -84,5 +83,10 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
     @Override
     public void showDefaultCategory() {
         categoryAdapter.setExampleCategories();
+    }
+
+    @Override
+    public void onFocus() {
+        //Do nothing - Intentional
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -18,6 +18,7 @@ import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 import io.intrepid.contest.screens.contestcreation.EditContestContract;
+import io.intrepid.contest.screens.contestcreation.addcategoriestocontest.AddCategoryActivity;
 import io.intrepid.contest.utils.dragdrop.SimpleItemTouchHelperCallback;
 
 

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
@@ -1,6 +1,7 @@
 package io.intrepid.contest.screens.contestcreation.describecontest;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import butterknife.BindView;
 import butterknife.OnTextChanged;

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
@@ -1,7 +1,6 @@
 package io.intrepid.contest.screens.contestcreation.describecontest;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import butterknife.BindView;
 import butterknife.OnTextChanged;
@@ -37,6 +36,11 @@ public class DescribeContestFragment extends BaseFragment<DescribeContestPresent
     @Override
     public void onNextClicked() {
         presenter.onNextClicked(descriptionField.getText());
+    }
+
+    @Override
+    public void onFocus() {
+        presenter.onTextChanged(descriptionField.getText());
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
@@ -41,7 +41,7 @@ public class NameContestFragment extends BaseFragment<NameContestPresenter> impl
 
     @Override
     public void onFocus() {
-        onTextChanged(contestNameField.getText());
+        presenter.onTextChanged(contestNameField.getText());
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
@@ -40,6 +40,11 @@ public class NameContestFragment extends BaseFragment<NameContestPresenter> impl
     }
 
     @Override
+    public void onFocus() {
+        onTextChanged(contestNameField.getText());
+    }
+
+    @Override
     public void setNextEnabled(boolean enabled) {
         ((EditContestContract) getActivity()).setNextEnabled(enabled);
         int trophyVisibility = enabled ? GONE : VISIBLE;

--- a/app/src/main/java/io/intrepid/contest/utils/SlidingTabAdapter.java
+++ b/app/src/main/java/io/intrepid/contest/utils/SlidingTabAdapter.java
@@ -33,15 +33,6 @@ public class SlidingTabAdapter extends FragmentStatePagerAdapter {
         return fragments.size();
     }
 
-    public void addFragment(int index, BaseFragment fragment) {
-        if(fragments.contains(fragment)){
-            fragments.remove(fragment);
-            notifyDataSetChanged();
-        }
-        fragments.add(index, fragment);
-        notifyDataSetChanged();
-    }
-
     public void addFragment(BaseFragment fragment) {
         fragments.add(fragment);
         notifyDataSetChanged();

--- a/app/src/main/java/io/intrepid/contest/utils/SlidingTabAdapter.java
+++ b/app/src/main/java/io/intrepid/contest/utils/SlidingTabAdapter.java
@@ -33,6 +33,15 @@ public class SlidingTabAdapter extends FragmentStatePagerAdapter {
         return fragments.size();
     }
 
+    public void addFragment(int index, BaseFragment fragment) {
+        if(fragments.contains(fragment)){
+            fragments.remove(fragment);
+            notifyDataSetChanged();
+        }
+        fragments.add(index, fragment);
+        notifyDataSetChanged();
+    }
+
     public void addFragment(BaseFragment fragment) {
         fragments.add(fragment);
         notifyDataSetChanged();


### PR DESCRIPTION
This bug occurs when you re-navigate to a tabbed fragment  that now has some text in it, and thus should display the next arrow.

EX: Go forward a few times, then go backwards to Name Contest…and then forward again to Describe Contest Page