### PR TITLE
CON-172 - Fixed Contest Creation Navigation Flow

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
@@ -3,5 +3,4 @@ package io.intrepid.contest.screens.contestcreation;
 public interface ContestCreationFragment{
 
     void onNextClicked();
-    void onFocus();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -13,7 +13,8 @@ import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
 class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> implements NewContestMvpContract.Presenter, ViewPager.OnPageChangeListener {
-    private static final int LAST_PAGE_INDEX = 2;
+    private static final int NAME_CONTEST_PAGE_INDEX = 0;
+    private static final int LAST_PAGE_INDEX = 3;
     private Contest.Builder contest;
 
     NewContestPresenter(@NonNull NewContestMvpContract.View view,
@@ -96,8 +97,10 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
 
     @Override
     public void onPageSelected(int position) {
-        ContestCreationFragment fragment = view.getChildEditFragment(position);
-        fragment.onFocus();
+        if (position == NAME_CONTEST_PAGE_INDEX) {
+            ValidatableView fragment = (ValidatableView) view.getChildEditFragment(position);
+            fragment.onFocus();
+        }
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ValidatableView.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ValidatableView.java
@@ -2,5 +2,5 @@ package io.intrepid.contest.screens.contestcreation;
 
 public interface ValidatableView {
 
-    void showError();
+    void onFocus();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
@@ -13,6 +13,7 @@ interface CategoriesListContract {
         void showAddCategoryScreen();
         void showNextScreen();
         void showEditCategoryPage(Category category);
+        void onCategoryClicked(Category category);
     }
 
     interface Presenter extends BaseContract.Presenter<CategoriesListContract.View> {

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -29,7 +29,7 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        categoryAdapter = new CategoryAdapter(getContext());
+        categoryAdapter = new CategoryAdapter(getContext(), R.layout.category_card_row_item);
     }
 
     @Override
@@ -91,7 +91,7 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
     }
 
     @Override
-    public void onFocus() {
-        //Do nothing - Intentional
+    public void onCategoryClicked(Category category) {
+        presenter.onCategoryClicked(category);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestContract.java
@@ -5,19 +5,11 @@ import io.intrepid.contest.base.BaseContract;
 class DescribeContestContract {
 
     public interface View extends BaseContract.View {
-
         void setNextEnabled(boolean enabled);
-
         void showNextScreen();
     }
 
     public interface Presenter<View> {
         void onNextClicked(String description);
-
-        void onNextInvalidated();
-
-        void onNextValidated();
-
-        void onTextChanged(CharSequence newDescription);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
@@ -3,7 +3,6 @@ package io.intrepid.contest.screens.contestcreation.describecontest;
 import android.support.annotation.NonNull;
 
 import butterknife.BindView;
-import butterknife.OnTextChanged;
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BaseFragment;
 import io.intrepid.contest.base.PresenterConfiguration;
@@ -28,19 +27,9 @@ public class DescribeContestFragment extends BaseFragment<DescribeContestPresent
         return new DescribeContestPresenter(this, configuration, contestBuilder);
     }
 
-    @OnTextChanged(R.id.hint_label_edit_text)
-    public final void onTextChanged(CharSequence newDescription) {
-        presenter.onTextChanged(newDescription);
-    }
-
     @Override
     public void onNextClicked() {
         presenter.onNextClicked(descriptionField.getText());
-    }
-
-    @Override
-    public void onFocus() {
-        presenter.onTextChanged(descriptionField.getText());
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestPresenter.java
@@ -1,7 +1,6 @@
 package io.intrepid.contest.screens.contestcreation.describecontest;
 
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.base.PresenterConfiguration;
@@ -21,31 +20,12 @@ class DescribeContestPresenter extends BasePresenter<DescribeContestContract.Vie
     @Override
     public void onViewCreated() {
         super.onViewCreated();
-        view.setNextEnabled(false);
+        view.setNextEnabled(true);
     }
 
     @Override
     public void onNextClicked(String description) {
         contestBuilder.setDescription(description);
         view.showNextScreen();
-    }
-
-    @Override
-    public void onNextInvalidated() {
-        view.setNextEnabled(false);
-    }
-
-    @Override
-    public void onNextValidated() {
-        view.setNextEnabled(true);
-    }
-
-    @Override
-    public void onTextChanged(CharSequence newDescription) {
-        if (TextUtils.isEmpty(newDescription)) {
-            view.setNextEnabled(false);
-        } else {
-            view.setNextEnabled(true);
-        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesFragment.java
@@ -15,7 +15,6 @@ import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.models.Category;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 
-
 public class EditCategoriesFragment extends BaseFragment<EditCategoriesPresenter> implements EditCategoriesContract.View, ContestCreationFragment {
     @BindView(R.id.category_name_edittext)
     EditText categoryNameField;
@@ -66,11 +65,6 @@ public class EditCategoriesFragment extends BaseFragment<EditCategoriesPresenter
     }
 
     @Override
-    public void onFocus() {
-        //Do nothing - Intentional
-    }
-
-    @Override
     public void addCategory(Category category) {
         activity.addCategory(category);
     }
@@ -85,4 +79,3 @@ public class EditCategoriesFragment extends BaseFragment<EditCategoriesPresenter
         void showCategoryList();
     }
 }
-

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
@@ -12,11 +12,12 @@ import io.intrepid.contest.customviews.HintLabelEditText;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 import io.intrepid.contest.screens.contestcreation.EditContestContract;
+import io.intrepid.contest.screens.contestcreation.ValidatableView;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
-public class NameContestFragment extends BaseFragment<NameContestPresenter> implements NameContestContract.View, ContestCreationFragment {
+public class NameContestFragment extends BaseFragment<NameContestPresenter> implements NameContestContract.View, ContestCreationFragment, ValidatableView {
     @BindView(R.id.contest_name_edittext)
     HintLabelEditText contestNameField;
     @BindView(R.id.trophy_icon)

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestFragment.java
@@ -19,7 +19,6 @@ import io.intrepid.contest.screens.contestcreation.EditContestContract;
 import io.intrepid.contest.screens.contestcreation.categorieslist.CategoryAdapter;
 
 public class ReviewContestFragment extends BaseFragment<ReviewContestPresenter> implements ReviewContestContract.View, ContestCreationFragment {
-    private static final String CONTEST_KEY = "CONTEST_KEY";
     @BindView(R.id.contest_title_button)
     TextView titleButton;
     @BindView(R.id.contest_description_button)
@@ -83,10 +82,5 @@ public class ReviewContestFragment extends BaseFragment<ReviewContestPresenter> 
     @Override
     public void onNextClicked() {
         //todo - submit contest
-    }
-
-    @Override
-    public void onFocus() {
-        //Do nothing - Intentional
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestPresenterTest.java
@@ -29,9 +29,9 @@ public class DescribeContestPresenterTest {
     }
 
     @Test
-    public void onViewCreatedShouldCauseViewToDisableNext() {
+    public void onViewCreatedShouldCauseViewToEnableNext() {
         describeContestPresenter.onViewCreated();
-        verify(mockView).setNextEnabled(false);
+        verify(mockView).setNextEnabled(true);
     }
 
     @Test
@@ -40,17 +40,4 @@ public class DescribeContestPresenterTest {
         describeContestPresenter.onNextClicked(VALID_TEXT);
         verify(mockView).showNextScreen();
     }
-
-    @Test
-    public void onNextValidatedShouldCauseViewToEnableNext() {
-        describeContestPresenter.onNextValidated();
-        verify(mockView).setNextEnabled(true);
-    }
-
-    @Test
-    public void onNextInValidatedShouldCauseViewToDisableNext() {
-        describeContestPresenter.onNextInvalidated();
-        verify(mockView).setNextEnabled(false);
-    }
 }
-


### PR DESCRIPTION
In contest creation flow, optional fields should allow going to the next screen.
Removed onFocus method from ContesCreationFragment interface, since the only classes that were previously using it were NameContestFragment and DescribeContestFragment.

The onFocus method has now been moved to ValidatableVIew interface.

The DescribeContestPresenter's interface has thus been simpliied. Same for the DescribeContestPresenter test suite.