### PR TITLE
Fix gson field naming policy to match the API

### DIFF
--- a/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RetrofitClient.java
@@ -69,7 +69,7 @@ public class RetrofitClient {
 
     private static Converter.Factory getConverter() {
         Gson gson = new GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .setPrettyPrinting()
                 .create();
         return GsonConverterFactory.create(gson);


### PR DESCRIPTION
Policy was wrong, so pojos were not getting assigned their variables.