### PR TITLE
Update contest status pojo according to api endpoint

### DIFF
--- a/app/src/main/java/io/intrepid/contest/rest/ContestStatus.java
+++ b/app/src/main/java/io/intrepid/contest/rest/ContestStatus.java
@@ -1,0 +1,39 @@
+package io.intrepid.contest.rest;
+
+public class ContestStatus {
+    private boolean submissionsEnded;
+    private int entriesSubmitted;
+    private int totalEntries;
+
+    private boolean contestEnded;
+    private int judgesSubmitted;
+    private int totalJudges;
+
+    public void setSubmissionData(boolean submissionsEnded, int entriesSubmitted, int totalEntries) {
+        this.submissionsEnded = submissionsEnded;
+        this.entriesSubmitted = entriesSubmitted;
+        this.totalEntries = totalEntries;
+    }
+
+    public void setJudgeData(boolean contestEnded, int judgesSubmitted, int totalJudges) {
+        this.contestEnded = contestEnded;
+        this.judgesSubmitted = judgesSubmitted;
+        this.totalJudges = totalJudges;
+    }
+
+    public int getNumSubmissionsMissing() {
+        return totalEntries - entriesSubmitted;
+    }
+
+    public int getNumScoresMissing() {
+        return totalJudges - judgesSubmitted;
+    }
+
+    public boolean haveSubmissionsEnded() {
+        return submissionsEnded;
+    }
+
+    public boolean hasContestEnded() {
+        return contestEnded;
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/rest/ContestStatusResponse.java
+++ b/app/src/main/java/io/intrepid/contest/rest/ContestStatusResponse.java
@@ -1,39 +1,5 @@
 package io.intrepid.contest.rest;
 
 public class ContestStatusResponse {
-    private boolean submissionsEnded;
-    private int entriesSubmitted;
-    private int totalEntries;
-
-    private boolean contestEnded;
-    private int judgesSubmitted;
-    private int totalJudges;
-
-    public void setSubmissionData(boolean submissionsEnded, int entriesSubmitted, int totalEntries) {
-        this.submissionsEnded = submissionsEnded;
-        this.entriesSubmitted = entriesSubmitted;
-        this.totalEntries = totalEntries;
-    }
-
-    public void setJudgeData(boolean contestEnded, int judgesSubmitted, int totalJudges) {
-        this.contestEnded = contestEnded;
-        this.judgesSubmitted = judgesSubmitted;
-        this.totalJudges = totalJudges;
-    }
-
-    public int getNumSubmissionsMissing() {
-        return totalEntries - entriesSubmitted;
-    }
-
-    public int getNumScoresMissing() {
-        return totalJudges - judgesSubmitted;
-    }
-
-    public boolean haveSubmissionsEnded() {
-        return submissionsEnded;
-    }
-
-    public boolean hasContestEnded() {
-        return contestEnded;
-    }
+    public ContestStatus contestStatus;
 }

--- a/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
@@ -89,16 +89,18 @@ public class MockRestApi implements RestApi {
     @NonNull
     private ContestStatusResponse getValidEntryResponseWaitingForSubmissions() {
         ContestStatusResponse response = new ContestStatusResponse();
-        response.setSubmissionData(false, 5, 10);
-        response.setJudgeData(false, 0, 6);
+        response.contestStatus = new ContestStatus();
+        response.contestStatus.setSubmissionData(false, 5, 10);
+        response.contestStatus.setJudgeData(false, 0, 6);
         return response;
     }
 
     @NonNull
     private ContestStatusResponse getValidEntryResponseWaitingForScores() {
         ContestStatusResponse response = new ContestStatusResponse();
-        response.setSubmissionData(true, 10, 10);
-        response.setJudgeData(false, 2, 6);
+        response.contestStatus = new ContestStatus();
+        response.contestStatus.setSubmissionData(true, 10, 10);
+        response.contestStatus.setJudgeData(false, 2, 6);
         return response;
     }
 

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenter.java
@@ -8,8 +8,8 @@ import io.intrepid.contest.R;
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.models.ParticipationType;
-import io.intrepid.contest.rest.ContestWrapper;
 import io.intrepid.contest.rest.ContestStatusResponse;
+import io.intrepid.contest.rest.ContestWrapper;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
@@ -54,12 +54,12 @@ class ContestStatusPresenter extends BasePresenter<ContestStatusContract.View> i
     }
 
     private void showContestStatusScreen(ContestStatusResponse response) {
-        if (!response.haveSubmissionsEnded()) {
-            view.showWaitingSubmissionsFragment(response.getNumSubmissionsMissing());
+        if (!response.contestStatus.haveSubmissionsEnded()) {
+            view.showWaitingSubmissionsFragment(response.contestStatus.getNumSubmissionsMissing());
             return;
         }
 
-        if (!response.hasContestEnded() &&
+        if (!response.contestStatus.hasContestEnded() &&
                 (persistentSettings.getCurrentParticipationType() == ParticipationType.JUDGE)) {
             view.showContestOverviewPage();
             return;

--- a/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.models.ParticipationType;
+import io.intrepid.contest.rest.ContestStatus;
 import io.intrepid.contest.rest.ContestWrapper;
 import io.intrepid.contest.rest.ContestStatusResponse;
 import io.intrepid.contest.screens.conteststatus.ContestStatusContract.Presenter;
@@ -53,8 +54,9 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @NonNull
     private ContestStatusResponse getContestStatusResponseWaitingForSubmissions() {
         ContestStatusResponse response = new ContestStatusResponse();
-        response.setSubmissionData(false, 0, 5);
-        response.setJudgeData(false, 0, 1);
+        response.contestStatus = new ContestStatus();
+        response.contestStatus.setSubmissionData(false, 0, 5);
+        response.contestStatus.setJudgeData(false, 0, 1);
         when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
         return response;
     }
@@ -62,8 +64,9 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @NonNull
     private ContestStatusResponse getContestStatusResponseWaitingForScores() {
         ContestStatusResponse response = new ContestStatusResponse();
-        response.setSubmissionData(true, 5, 5);
-        response.setJudgeData(false, 0, 1);
+        response.contestStatus = new ContestStatus();
+        response.contestStatus.setSubmissionData(true, 5, 5);
+        response.contestStatus.setJudgeData(false, 0, 1);
         when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
         return response;
     }
@@ -71,8 +74,9 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @NonNull
     private ContestStatusResponse getContestStatusResponseResultsAvailable() {
         ContestStatusResponse response = new ContestStatusResponse();
-        response.setSubmissionData(true, 5, 5);
-        response.setJudgeData(true, 1, 1);
+        response.contestStatus = new ContestStatus();
+        response.contestStatus.setSubmissionData(true, 5, 5);
+        response.contestStatus.setJudgeData(true, 1, 1);
         when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
         return response;
     }
@@ -84,7 +88,7 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
         presenter.onViewCreated();
         testConfiguration.triggerRxSchedulers();
 
-        verify(mockView).showWaitingSubmissionsFragment(response.getNumSubmissionsMissing());
+        verify(mockView).showWaitingSubmissionsFragment(response.contestStatus.getNumSubmissionsMissing());
         verify(mockView, never()).showResultsAvailableFragment();
         verify(mockView, never()).showContestOverviewPage();
     }
@@ -123,7 +127,7 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
         testConfiguration.getIoScheduler().advanceTimeBy(3, TimeUnit.SECONDS);
         testConfiguration.triggerRxSchedulers();
 
-        verify(mockView, times(2)).showWaitingSubmissionsFragment(response.getNumSubmissionsMissing());
+        verify(mockView, times(2)).showWaitingSubmissionsFragment(response.contestStatus.getNumSubmissionsMissing());
     }
 
     @Test


### PR DESCRIPTION
Before, the `ContestStatusResponse` pojo had the variables directly. However there is a "contest_status" key wrapping that, so code was changed to account for that.