### PR TITLE
CON-196: Fix API endpoint to submit entry image

### DIFF
--- a/app/src/main/java/io/intrepid/contest/rest/EntryRequest.java
+++ b/app/src/main/java/io/intrepid/contest/rest/EntryRequest.java
@@ -15,12 +15,12 @@ public class EntryRequest {
     @SerializedName("entry")
     private final HashMap<String, Object> entry;
 
-    public EntryRequest(String title, Bitmap photo) {
+    public EntryRequest(String title, Bitmap photo, String formatPrefix, Bitmap.CompressFormat format, int quality) {
         entry = new HashMap<>();
         entry.put(TITLE_KEY, title);
 
         if (photo != null) {
-            entry.put(PICTURE_DATA_KEY, ImageUtils.convert(photo));
+            entry.put(PICTURE_DATA_KEY, formatPrefix + ImageUtils.convert(photo, format, quality));
         }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
@@ -12,6 +12,14 @@ import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
 class EntryImagePresenter extends BasePresenter<EntryImageContract.View> implements EntryImageContract.Presenter {
+    /**
+     * Quality ranges from 0-100: 0 meaning compress for small size, 100 meaning compress for max quality.
+     * Lossless formats like PGN will ignore this setting.
+     */
+    private static final int QUALITY = 100;
+    private static final Bitmap.CompressFormat FORMAT = Bitmap.CompressFormat.PNG;
+    private static final String FORMAT_PREFIX = "data:image/png;base64,";
+
     private Bitmap bitmap;
     private String entryName;
 
@@ -47,7 +55,7 @@ class EntryImagePresenter extends BasePresenter<EntryImageContract.View> impleme
         Timber.d("Entry creation API call.");
 
         String contestId = persistentSettings.getCurrentContestId().toString();
-        EntryRequest entryRequest = new EntryRequest(entryName, bitmap);
+        EntryRequest entryRequest = new EntryRequest(entryName, bitmap, FORMAT_PREFIX, FORMAT, QUALITY);
 
         Disposable disposable = restApi.createEntry(contestId, entryRequest)
                 .compose(subscribeOnIoObserveOnUi())

--- a/app/src/main/java/io/intrepid/contest/utils/ImageUtils.java
+++ b/app/src/main/java/io/intrepid/contest/utils/ImageUtils.java
@@ -6,17 +6,11 @@ import android.util.Base64;
 import java.io.ByteArrayOutputStream;
 
 public class ImageUtils {
-    /**
-     * Quality ranges from 0-100: 0 meaning compress for small size, 100 meaning compress for max quality.
-     * Lossless formats like PGN will ignore this setting.
-     */
-    private static final int QUALITY = 100;
-    private static final Bitmap.CompressFormat FORMAT = Bitmap.CompressFormat.PNG;
-
-    public static String convert(Bitmap bitmap) {
+    public static String convert(Bitmap bitmap, Bitmap.CompressFormat format, int quality) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        bitmap.compress(FORMAT, QUALITY, outputStream);
+        bitmap.compress(format, quality, outputStream);
 
-        return Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
+        String imageEncoded = Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
+        return imageEncoded.replace(" ", "").replace("\n", "");
     }
 }


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-196

- API endpoint needed to receive a prefix.
- Presenter was not deciding the format/quality of the picture

IMPORTANT:
How to test:
1. Uninstall the app
2. Install it again (so you have a fresh)
3. If you are not using the QA build to install it, go 
4. Join a contest
5. Enter **one** of the following codes:
- 1adSkR3
- wvCVymv
- frkgUx8
(If they're all used up, please see steps 9-10)
6. Create an entry
7. Select an image
8. Click submit and **wait** (there's no progress bar, so it takes a few seconds)
You should see a successful message. If it says it's waiting on 0 contestants it's because no one else that was invited redeemed the code, and the submissions have not been ended automatically or manually.


9. If needed: With postman, send an invitation: https://github.com/IntrepidPursuits/contest-app-server/wiki/Send-an-Invitation-%60POST-api-contests-:id-batch_invite%60
`token=6cc05102-68cb-496e-b5fd-b9e08ea2fad2`
`"contest_id": "1d8d10de-0b8b-42f9-9e4b-d523c1348294"`
Use a phone in the following format: `"phone": "111-xxx-xxxx"`.