### PR TITLE
CON-197: Back button behavior in send invitations screen

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivity.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.app.Fragment;
@@ -54,10 +53,13 @@ public class SendInvitationsActivity extends BaseMvpActivity<SendInvitationsCont
     }
 
     @Override
-    protected void onViewCreated(Bundle savedInstanceState) {
-        super.onViewCreated(savedInstanceState);
+    public void onBackPressed() {
+        presenter.onBackButtonClicked();
+    }
 
-        setActionBarDisplayHomeAsUpEnabled(true);
+    @Override
+    public void setActionBarDisplayHomeAsUpEnabled(boolean enabled) {
+        super.setActionBarDisplayHomeAsUpEnabled(enabled);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivityContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivityContract.java
@@ -12,4 +12,6 @@ public interface SendInvitationsActivityContract {
     List<Contact> getContactList();
 
     void onAddContestantsButtonClicked(List<Contact> contactList);
+
+    void onBackPressed();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsContract.java
@@ -9,6 +9,10 @@ import io.intrepid.contest.models.Contact;
 
 class SendInvitationsContract {
     interface View extends BaseContract.View {
+        void setActionBarTitle(@StringRes int titleResource);
+
+        void setActionBarDisplayHomeAsUpEnabled(boolean enabled);
+
         boolean checkContactsPermissions();
 
         void requestContactsPermissions();
@@ -22,11 +26,11 @@ class SendInvitationsContract {
         void showSelectContactsFragment();
 
         void showInvitationIntroFragment();
-
-        void setActionBarTitle(@StringRes int titleResource);
     }
 
     interface Presenter extends BaseContract.Presenter<View> {
+        void onBackButtonClicked();
+
         void onSelectContactsButtonClicked();
 
         void onAddContestantsButtonClicked(List<Contact> selectedContactList);

--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenter.java
@@ -16,7 +16,7 @@ public class SendInvitationsPresenter extends BasePresenter<SendInvitationsContr
     private final List<Contact> fullContactList = new ArrayList<>();
     private final List<Contact> selectedContactList = new ArrayList<>();
     private boolean contactSelectionEnabled = false;
-    private boolean displayMenuItems = true;
+    private boolean displayMenuItemsAndActionBar = true;
 
     public SendInvitationsPresenter(@NonNull SendInvitationsContract.View view,
                                     @NonNull PresenterConfiguration configuration) {
@@ -67,7 +67,7 @@ public class SendInvitationsPresenter extends BasePresenter<SendInvitationsContr
     }
 
     private void showSelectContactsContent() {
-        displayMenuItems = false;
+        displayMenuItemsAndActionBar = false;
 
         view.showSelectContactsButton(false);
 
@@ -91,7 +91,7 @@ public class SendInvitationsPresenter extends BasePresenter<SendInvitationsContr
     }
 
     private void showPreviewContent() {
-        displayMenuItems = true;
+        displayMenuItemsAndActionBar = true;
         boolean hasPermissions = hasContactPermissions();
         view.showSelectContactsButton(hasPermissions);
 
@@ -110,7 +110,7 @@ public class SendInvitationsPresenter extends BasePresenter<SendInvitationsContr
 
     @Override
     public void onCreateOptionsMenu() {
-        displayMenuItems();
+        updateMenuItemsAndActionBar();
     }
 
     @Override
@@ -122,17 +122,27 @@ public class SendInvitationsPresenter extends BasePresenter<SendInvitationsContr
                 break;
             case R.id.send_invitations_skip_menu_action:
                 view.showMessage("TODO: Go to next screen");
+            case android.R.id.home:
+                onBackButtonClicked();
         }
     }
 
-    private void displayMenuItems() {
-        if (displayMenuItems) {
+    private void updateMenuItemsAndActionBar() {
+        if (displayMenuItemsAndActionBar) {
             view.setActionBarTitle(R.string.invite_contestants_bar_title);
+            view.setActionBarDisplayHomeAsUpEnabled(false);
             view.showSendInvitationsMenuItem(!selectedContactList.isEmpty());
             view.showSendInvitationsSkipMenuItem(selectedContactList.isEmpty());
         } else {
             view.showSendInvitationsMenuItem(false);
             view.showSendInvitationsSkipMenuItem(false);
+        }
+    }
+
+    @Override
+    public void onBackButtonClicked() {
+        if (contactSelectionEnabled) {
+            showPreviewContent();
         }
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenterTest.java
@@ -134,6 +134,13 @@ public class SendInvitationsPresenterTest extends BasePresenterTest<SendInvitati
     }
 
     @Test
+    public void onBackButtonClickedShouldShowPreviewInvitationWhenShowingSelectContactsContent() {
+        showSelectContactsContent();
+        presenter.onBackButtonClicked();
+        verify(mockView).showInvitationIntroFragment();
+    }
+
+    @Test
     public void onContactsPermissionsResultShouldHideSelectContactsButtonWhenPermissionHasBeenDenied() {
         when(mockView.checkContactsPermissions()).thenReturn(false);
         presenter.onContactsPermissionsResult();


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-197

- Cannot go back to contest creation when seeing "preview content" (intro message or selected contacts)
- Should go back to "preview content" if currently selecting contacts