### PR TITLE
Con 200 - Categories List should hide next screen

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -14,6 +14,7 @@ import timber.log.Timber;
 
 class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> implements NewContestMvpContract.Presenter, ViewPager.OnPageChangeListener {
     private static final int NAME_CONTEST_PAGE_INDEX = 0;
+    private static final int CATEGORIES_LIST_PAGE_INDEX = 2;
     private static final int LAST_PAGE_INDEX = 3;
     private Contest.Builder contest;
 
@@ -98,7 +99,7 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
 
     @Override
     public void onPageSelected(int position) {
-        if (position == NAME_CONTEST_PAGE_INDEX) {
+        if (position == NAME_CONTEST_PAGE_INDEX || position == CATEGORIES_LIST_PAGE_INDEX) {
             ValidatableView fragment = (ValidatableView) view.getChildEditFragment(position);
             fragment.onFocus();
         }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 import io.intrepid.contest.base.BaseContract;
 import io.intrepid.contest.models.Category;
+import io.intrepid.contest.screens.contestcreation.ValidatableView;
 
 interface CategoriesListContract {
 
-    interface View extends BaseContract.View {
+    interface View extends BaseContract.View, ValidatableView {
         void showCategories(List<Category> categories);
 
         void showAddCategoryScreen();
@@ -17,6 +18,8 @@ interface CategoriesListContract {
         void showEditCategoryPage(Category category);
 
         Category getDefaultCategory(int categoryName, int categoryDescription);
+
+        void setNextEnabled(boolean enabled);
     }
 
     interface Presenter extends BaseContract.Presenter<CategoriesListContract.View>, CategoryClickListener {

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -19,8 +19,11 @@ import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 import io.intrepid.contest.screens.contestcreation.EditContestContract;
-import io.intrepid.contest.screens.contestcreation.editcategoriestocontest.EditCategoryActivity;
 import io.intrepid.contest.utils.dragdrop.SimpleItemTouchHelperCallback;
+import timber.log.Timber;
+
+import static io.intrepid.contest.screens.contestcreation.editcategoriestocontest.EditCategoryActivity.NOTIFY_EDIT_EXISTING_CATEGORY;
+import static io.intrepid.contest.screens.contestcreation.editcategoriestocontest.EditCategoryActivity.makeEditCategoryIntent;
 
 
 public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter> implements CategoriesListContract.View, ContestCreationFragment {
@@ -79,13 +82,14 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
 
     @Override
     public void showEditCategoryPage(Category category) {
-        Intent intent = EditCategoryActivity.makeEditCategoryIntent(getContext(), category);
-        getActivity().startActivityForResult(intent, EditCategoryActivity.NOTIFY_EDIT_EXISTING_CATEGORY);
+        Intent intent = makeEditCategoryIntent(getContext(), category);
+        getActivity().startActivityForResult(intent, NOTIFY_EDIT_EXISTING_CATEGORY);
     }
 
     @Override
     public void showCategories(List<Category> categories) {
         categoryAdapter.setCategories(categories);
+        Timber.d("Categories size " + categoryAdapter.getItemCount());
     }
 
     @Override
@@ -93,5 +97,21 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
         String categoryName = getString(categoryNameRes);
         String categoryDescription = getString(categoryDescriptionRes);
         return new Category(categoryName, categoryDescription);
+    }
+
+    @Override
+    public void setNextEnabled(boolean enabled) {
+        ((EditContestContract) getActivity()).setNextEnabled(enabled);
+    }
+
+    @Override
+    public void onFocus() {
+        if (presenter != null) {
+            /* The presenter may not have been created yet, though onFocus was forcefully called.
+              If presenter is null, the onViewBound method will still be called when
+               the fragment is instantiated
+             */
+            presenter.onViewBound();
+        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
@@ -37,6 +37,12 @@ class CategoriesListPresenter extends BasePresenter<CategoriesListContract.View>
     }
 
     @Override
+    protected void onViewBound() {
+        super.onViewBound();
+        determineNextIconVisibility();
+    }
+
+    @Override
     public void displayCategories() {
         view.showCategories(contestBuilder.getCategories());
     }
@@ -61,5 +67,11 @@ class CategoriesListPresenter extends BasePresenter<CategoriesListContract.View>
     public void onDeleteClicked(Category category) {
         contestBuilder.getCategories().remove(category);
         view.showCategories(contestBuilder.getCategories());
+        determineNextIconVisibility();
+    }
+
+    private void determineNextIconVisibility() {
+        boolean nextEnabled = !contestBuilder.getCategories().isEmpty();
+        view.setNextEnabled(nextEnabled);
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.java
@@ -13,6 +13,9 @@ import io.intrepid.contest.testutils.BasePresenterTest;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,9 +42,59 @@ public class CategoriesListPresenterTest extends BasePresenterTest<CategoriesLis
     }
 
     @Test
+    public void onViewBoundShouldEnableNextWhenCategoriesIsNotEmpty() {
+        presenter.onViewBound();
+        verify(mockView).setNextEnabled(true);
+    }
+
+    @Test
+    public void onViewBoundShouldDisableNextWhenCategoriesIsEmpty() {
+        when(mockContestBuilder.getCategories()).thenReturn(new ArrayList<>());
+        presenter.onViewBound();
+        verify(mockView).setNextEnabled(false);
+    }
+
+    @Test
+    public void onDeleteClickedShouldNeverDisableWhenCategoriesIsNotEmpty() {
+        List<Category> categories = mockContestBuilder.getCategories();
+        for (int i = 0; i < categories.size() - 1; i++) {
+            presenter.onDeleteClicked(categories.get(i));
+        }
+
+        verify(mockView, never()).setNextEnabled(false);
+        verify(mockView, times(categories.size() - 1)).setNextEnabled(true);
+    }
+
+    @Test
+    public void onDeleteClickedShouldDisableNextWhenCategoriesIsEmpty() {
+        List<Category> singleCategoryList = new ArrayList<>();
+        Category singleCategory = new Category("Single Category", "TEST");
+        singleCategoryList.add(singleCategory);
+        when(mockContestBuilder.getCategories()).thenReturn(new ArrayList<>());
+
+        presenter.onDeleteClicked(singleCategory);
+
+        verify(mockView).setNextEnabled(false);
+        verify(mockView, never()).setNextEnabled(true);
+    }
+
+    @Test
     public void onViewShouldCreatedShouldTriggerViewToShowCategories() {
         presenter.onViewCreated();
         verify(mockView).showCategories(any());
+    }
+
+    @Test
+    public void onViewBoundShouldTriggerViewToSetNextEnabled() {
+        presenter.onViewBound();
+        verify(mockView).setNextEnabled(true);
+    }
+
+    @Test
+    public void onViewBoundShouldTriggerViewToDisableNextWhenCategoriesIsEmpty() {
+        when(mockContestBuilder.getCategories()).thenReturn(new ArrayList<>());
+        presenter.onViewBound();
+        verify(mockView).setNextEnabled(false);
     }
 
     @Test


### PR DESCRIPTION
Categories List should hide next screen when all categories have been removed.
It should reappear when the categories list is no longer empty.

Still figuring out with design how to handle the empty screen that results from emptying all the categories. 