### PR TITLE
CON-211: Results screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
         <activity android:name=".screens.contestoverview.ContestOverviewActivity"/>
         <activity android:name=".screens.sendinvitations.SendInvitationsActivity"/>
         <activity android:name=".screens.contestjudging.scoreentries.ScoreEntriesActivity"/>
+        <activity android:name=".screens.contestresults.ContestResultsActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/io/intrepid/contest/models/ContestResult.java
+++ b/app/src/main/java/io/intrepid/contest/models/ContestResult.java
@@ -1,0 +1,7 @@
+package io.intrepid.contest.models;
+
+import java.util.List;
+
+public class ContestResult {
+    public List<RankedEntryResult> rankedScoredEntries;
+}

--- a/app/src/main/java/io/intrepid/contest/models/RankedEntryResult.java
+++ b/app/src/main/java/io/intrepid/contest/models/RankedEntryResult.java
@@ -1,0 +1,40 @@
+package io.intrepid.contest.models;
+
+public class RankedEntryResult {
+    private String title;
+    private String photoUrl;
+    private float overallScore;
+    private int rank;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getPhotoUrl() {
+        return photoUrl;
+    }
+
+    public void setPhotoUrl(String photoUrl) {
+        this.photoUrl = photoUrl;
+    }
+
+    public float getOverallScore() {
+        return overallScore;
+    }
+
+    public void setOverallScore(float overallScore) {
+        this.overallScore = overallScore;
+    }
+
+    public int getRank() {
+        return rank;
+    }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/rest/ContestResultResponse.java
+++ b/app/src/main/java/io/intrepid/contest/rest/ContestResultResponse.java
@@ -1,0 +1,18 @@
+package io.intrepid.contest.rest;
+
+import java.util.List;
+
+import io.intrepid.contest.models.ContestResult;
+import io.intrepid.contest.models.RankedEntryResult;
+
+public class ContestResultResponse {
+    public ContestResult contestResults;
+
+    public ContestResultResponse() {
+    }
+
+    public ContestResultResponse(List<RankedEntryResult> rankedScoredEntries) {
+        this.contestResults = new ContestResult();
+        contestResults.rankedScoredEntries = rankedScoredEntries;
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
@@ -11,6 +11,7 @@ import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.models.Entry;
 import io.intrepid.contest.models.Participant;
 import io.intrepid.contest.models.ParticipationType;
+import io.intrepid.contest.models.RankedEntryResult;
 import io.intrepid.contest.models.User;
 import io.reactivex.Observable;
 import retrofit2.http.Body;
@@ -140,8 +141,10 @@ public class MockRestApi implements RestApi {
         numGetContestStatusCallsForParticipant++;
 
         switch (numGetContestStatusCallsForParticipant) {
-            case 1: return Observable.just(getValidStatusResponseWaitingForSubmissions());
-            case 2: return Observable.just(getValidStatusResponseWaitingForScores());
+            case 1:
+                return Observable.just(getValidStatusResponseWaitingForSubmissions());
+            case 2:
+                return Observable.just(getValidStatusResponseWaitingForScores());
             default:
                 numGetContestStatusCallsForParticipant = 0;
                 return Observable.just(getValidStatusResponseResultsAvailable());
@@ -176,5 +179,49 @@ public class MockRestApi implements RestApi {
     @Override
     public Observable<ContestWrapper> getContestDetails(@Path("contestId") String contestId) {
         return Observable.just(getValidContestResponse());
+    }
+
+    private ContestResultResponse getValidContestResultResponse() {
+        RankedEntryResult firstPlace = new RankedEntryResult();
+        firstPlace.setTitle("Awesome Sauce");
+        firstPlace.setOverallScore(4.25f);
+        firstPlace.setRank(1);
+        firstPlace.setPhotoUrl(
+                "https://search.chow.com/thumbnail/800/600/www.chowstatic.com/assets/recipe_photos/10828_smoked_chili.jpg");
+
+        RankedEntryResult secondPlace = new RankedEntryResult();
+        secondPlace.setTitle("Dank Chili");
+        secondPlace.setOverallScore(4.05f);
+        secondPlace.setRank(2);
+        secondPlace.setPhotoUrl("https://upload.wikimedia.org/wikipedia/commons/0/0f/Pot-o-chili.jpg");
+
+        RankedEntryResult thirdPlace = new RankedEntryResult();
+        thirdPlace.setTitle("Chill Chili");
+        thirdPlace.setOverallScore(3.50f);
+        thirdPlace.setRank(3);
+        thirdPlace.setPhotoUrl(
+                "http://cf.familyfreshmeals.com/wp-content/uploads/2015/10/Easy-Crockpot-Chili-Step-2.png");
+
+        RankedEntryResult fourthPlace = new RankedEntryResult();
+        fourthPlace.setTitle("Sweet Chili");
+        fourthPlace.setOverallScore(3.25f);
+        fourthPlace.setRank(4);
+        fourthPlace.setPhotoUrl("http://del.h-cdn.co/assets/15/41/cornbread-waffles-with-chili3.jpg");
+
+        List<RankedEntryResult> rankedScoredEntries = new ArrayList<>();
+        rankedScoredEntries.add(firstPlace);
+        rankedScoredEntries.add(secondPlace);
+        rankedScoredEntries.add(thirdPlace);
+        rankedScoredEntries.add(fourthPlace);
+
+        return new ContestResultResponse(rankedScoredEntries);
+    }
+
+    @Override
+    public Observable<ContestResultResponse> getContestResults(@Path("contestId") String contestId) {
+        if (contestId == null) {
+            return Observable.error(new Throwable());
+        }
+        return Observable.just(getValidContestResultResponse());
     }
 }

--- a/app/src/main/java/io/intrepid/contest/rest/RestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RestApi.java
@@ -30,4 +30,7 @@ public interface RestApi {
 
     @GET("api/contests/{contestId}")
     Observable<ContestWrapper> getContestDetails(@Path("contestId") String contestId);
+
+    @GET("api/contests/{contestId}/results")
+    Observable<ContestResultResponse> getContestResults(@Path("contestId") String contestId);
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsActivity.java
@@ -1,0 +1,64 @@
+package io.intrepid.contest.screens.contestresults;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.widget.TextView;
+
+import java.util.List;
+
+import butterknife.BindView;
+import io.intrepid.contest.R;
+import io.intrepid.contest.base.BaseMvpActivity;
+import io.intrepid.contest.base.PresenterConfiguration;
+import io.intrepid.contest.models.RankedEntryResult;
+
+import static android.view.View.GONE;
+
+public class ContestResultsActivity extends BaseMvpActivity<ContestResultsContract.Presenter>
+        implements ContestResultsContract.View {
+
+    @BindView(R.id.generic_recycler_view)
+    RecyclerView contestResultsRecyclerView;
+    @BindView(R.id.contest_results_no_entries_text_view)
+    TextView noEntriesTextView;
+
+    private ContestResultsAdapter contestResultsAdapter;
+
+    public static Intent makeIntent(Context context) {
+        return new Intent(context, ContestResultsActivity.class);
+    }
+
+    @NonNull
+    @Override
+    public ContestResultsContract.Presenter createPresenter(PresenterConfiguration configuration) {
+        return new ContestResultsPresenter(this, configuration);
+    }
+
+    @Override
+    protected int getLayoutResourceId() {
+        return R.layout.activity_contest_results;
+    }
+
+    @Override
+    protected void onViewCreated(Bundle savedInstanceState) {
+        super.onViewCreated(savedInstanceState);
+
+        contestResultsAdapter = new ContestResultsAdapter();
+        contestResultsRecyclerView.setAdapter(contestResultsAdapter);
+        contestResultsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+    }
+
+    @Override
+    public void showResults(List<RankedEntryResult> entryResults) {
+        contestResultsAdapter.updateResultsList(entryResults);
+    }
+
+    @Override
+    public void hideNoEntriesMessage() {
+        noEntriesTextView.setVisibility(GONE);
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsAdapter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsAdapter.java
@@ -1,0 +1,35 @@
+package io.intrepid.contest.screens.contestresults;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.intrepid.contest.models.RankedEntryResult;
+
+class ContestResultsAdapter extends RecyclerView.Adapter<ContestResultsViewHolder> {
+    private final List<RankedEntryResult> rankedEntryResults = new ArrayList<>();
+
+    @Override
+    public ContestResultsViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        return new ContestResultsViewHolder(parent);
+    }
+
+    @Override
+    public void onBindViewHolder(ContestResultsViewHolder holder, int position) {
+        holder.bindResultData(rankedEntryResults.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return rankedEntryResults.size();
+    }
+
+    public void updateResultsList(@NonNull List<RankedEntryResult> rankedEntryResults) {
+        this.rankedEntryResults.clear();
+        this.rankedEntryResults.addAll(rankedEntryResults);
+        notifyDataSetChanged();
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsContract.java
@@ -1,0 +1,18 @@
+package io.intrepid.contest.screens.contestresults;
+
+import java.util.List;
+
+import io.intrepid.contest.base.BaseContract;
+import io.intrepid.contest.models.RankedEntryResult;
+
+class ContestResultsContract {
+    interface View extends BaseContract.View {
+        void showResults(List<RankedEntryResult> entryResults);
+
+        void hideNoEntriesMessage();
+    }
+
+    interface Presenter extends BaseContract.Presenter<View> {
+
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsPresenter.java
@@ -1,0 +1,49 @@
+package io.intrepid.contest.screens.contestresults;
+
+import android.support.annotation.NonNull;
+
+import java.util.List;
+
+import io.intrepid.contest.R;
+import io.intrepid.contest.base.BasePresenter;
+import io.intrepid.contest.base.PresenterConfiguration;
+import io.intrepid.contest.models.RankedEntryResult;
+import io.intrepid.contest.rest.ContestResultResponse;
+import io.reactivex.disposables.Disposable;
+import timber.log.Timber;
+
+public class ContestResultsPresenter extends BasePresenter<ContestResultsContract.View>
+        implements ContestResultsContract.Presenter {
+
+    public ContestResultsPresenter(@NonNull ContestResultsContract.View view,
+                                   @NonNull PresenterConfiguration configuration) {
+        super(view, configuration);
+    }
+
+    @Override
+    public void onViewCreated() {
+        super.onViewCreated();
+
+        String contestId = persistentSettings.getCurrentContestId().toString();
+        Disposable apiCallDisposable = restApi.getContestResults(contestId)
+                .compose(subscribeOnIoObserveOnUi())
+                .subscribe(contestResultResponse -> showResults(contestResultResponse), throwable -> {
+                    Timber.d("API error retrieving contest results: " + throwable.getMessage());
+                    view.showMessage(R.string.error_api);
+                });
+        disposables.add(apiCallDisposable);
+    }
+
+    private void showResults(ContestResultResponse contestResultResponse) {
+        if (contestResultResponse.contestResults == null) {
+            return;
+        }
+
+        List<RankedEntryResult> entryResults = contestResultResponse.contestResults.rankedScoredEntries;
+
+        if (!entryResults.isEmpty()) {
+            view.hideNoEntriesMessage();
+            view.showResults(entryResults);
+        }
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsViewHolder.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestresults/ContestResultsViewHolder.java
@@ -1,0 +1,66 @@
+package io.intrepid.contest.screens.contestresults;
+
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.squareup.picasso.Picasso;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import io.intrepid.contest.R;
+import io.intrepid.contest.models.RankedEntryResult;
+
+class ContestResultsViewHolder extends RecyclerView.ViewHolder {
+
+    @BindView(R.id.contest_result_entry_image_view)
+    ImageView entryImage;
+    @BindView(R.id.contest_result_entry_score_text_view)
+    TextView entryScore;
+    @BindView(R.id.contest_result_entry_title_text_view)
+    TextView entryTitle;
+    @BindView(R.id.contest_result_entry_rank_text_view)
+    TextView entryRank;
+
+    ContestResultsViewHolder(ViewGroup parent) {
+        super(inflateView(parent));
+        ButterKnife.bind(this, itemView);
+    }
+
+    private static View inflateView(ViewGroup parent) {
+        LayoutInflater layoutInflater = LayoutInflater.from(parent.getContext());
+        return layoutInflater.inflate(R.layout.contest_result_row_item, parent, false);
+    }
+
+    void bindResultData(RankedEntryResult rankedEntryResult) {
+        Picasso.with(itemView.getContext()).load(rankedEntryResult.getPhotoUrl()).into(entryImage);
+        entryScore.setText(String.valueOf(rankedEntryResult.getOverallScore()));
+        entryTitle.setText(rankedEntryResult.getTitle());
+
+        int backgroundColorResource;
+        int rankTextResource;
+        switch (rankedEntryResult.getRank()) {
+            case 1:
+                backgroundColorResource = R.color.colorFirstPlaceResult;
+                rankTextResource = R.string.contest_result_first_place;
+                break;
+            case 2:
+                backgroundColorResource = R.color.colorSecondPlaceResult;
+                rankTextResource = R.string.contest_result_second_place;
+                break;
+            case 3:
+                backgroundColorResource = R.color.colorThirdPlaceResult;
+                rankTextResource = R.string.contest_result_third_place;
+                break;
+            default:
+                backgroundColorResource = R.color.colorOtherPlacesResult;
+                rankTextResource = R.string.contest_result_other_places;
+        }
+        itemView.setBackgroundColor(ContextCompat.getColor(itemView.getContext(), backgroundColorResource));
+        entryRank.setText(rankTextResource);
+    }
+}

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailableFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailableFragment.java
@@ -11,6 +11,7 @@ import io.intrepid.contest.R;
 import io.intrepid.contest.base.BaseFragment;
 import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.rest.ContestWrapper;
+import io.intrepid.contest.screens.contestresults.ContestResultsActivity;
 import io.intrepid.contest.screens.conteststatus.ContestStatusActivityContract;
 import io.reactivex.functions.Consumer;
 import timber.log.Timber;
@@ -56,7 +57,7 @@ public class ResultsAvailableFragment extends BaseFragment<ResultsAvailableContr
 
     @Override
     public void showResultsPage() {
-        Timber.d("Show results page");
+        startActivity(ContestResultsActivity.makeIntent(getActivity()));
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailablePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/resultsavailable/ResultsAvailablePresenter.java
@@ -40,6 +40,5 @@ public class ResultsAvailablePresenter extends BasePresenter<ResultsAvailableCon
     @Override
     public void onViewResultsButtonClicked() {
         view.showResultsPage();
-        view.showMessage("Show results page");
     }
 }

--- a/app/src/main/res/layout/activity_contest_results.xml
+++ b/app/src/main/res/layout/activity_contest_results.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_contest_results"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="io.intrepid.contest.screens.contestresults.ContestResultsActivity"
+    >
+
+    <TextView
+        android:id="@+id/contest_results_no_entries_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/contest_results_no_entries_message"
+        />
+
+    <include layout="@layout/include_layout_recycler_view"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/contest_result_row_item.xml
+++ b/app/src/main/res/layout/contest_result_row_item.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/contest_result_row_item_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/contest_result_row_vertical_padding"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/contest_result_row_vertical_padding"
+    >
+
+    <android.support.v7.widget.CardView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        app:cardElevation="@dimen/contest_result_card_elevation"
+        app:cardUseCompatPadding="true"
+        >
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/contest_result_entry_image_height"
+            android:paddingLeft="@dimen/contest_result_content_horizontal_spacing"
+            android:paddingStart="@dimen/contest_result_content_horizontal_spacing"
+            >
+
+            <ImageView
+                android:id="@+id/contest_result_entry_image_view"
+                android:layout_width="@dimen/contest_result_entry_image_width"
+                android:layout_height="@dimen/contest_result_entry_image_height"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_marginLeft="@dimen/contest_result_content_horizontal_spacing"
+                android:layout_marginStart="@dimen/contest_result_content_horizontal_spacing"
+                android:adjustViewBounds="true"
+                android:scaleType="centerCrop"
+                />
+
+            <TextView
+                android:id="@+id/contest_result_entry_score_text_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_marginTop="@dimen/contest_result_content_vertical_spacing"
+                android:layout_toLeftOf="@id/contest_result_entry_image_view"
+                android:layout_toStartOf="@id/contest_result_entry_image_view"
+                android:textSize="@dimen/contest_result_entry_score_textsize"
+                />
+
+            <TextView
+                android:id="@+id/contest_result_entry_rank_text_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_marginBottom="@dimen/contest_result_content_vertical_spacing"
+                android:layout_toLeftOf="@id/contest_result_entry_image_view"
+                android:layout_toStartOf="@id/contest_result_entry_image_view"
+                android:textAppearance="@style/AvenirNext_Medium"
+                android:textColor="@color/colorAccent"
+                android:textSize="@dimen/contest_result_entry_rank_textsize"
+                />
+
+            <TextView
+                android:id="@+id/contest_result_entry_title_text_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_above="@id/contest_result_entry_rank_text_view"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_toLeftOf="@id/contest_result_entry_image_view"
+                android:layout_toStartOf="@id/contest_result_entry_image_view"
+                android:textAppearance="@style/AvenirNext_DemiBold"
+                android:textSize="@dimen/contest_result_entry_title_textsize"
+                />
+
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</FrameLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,4 +19,9 @@
     <color name="category_card_background">#fdfdfd</color>
 
     <color name="submissionPromptTextColor">#131313</color>
+
+    <color name="colorFirstPlaceResult">#f0bf22</color>
+    <color name="colorSecondPlaceResult">#b1b6bc</color>
+    <color name="colorThirdPlaceResult">#d4862f</color>
+    <color name="colorOtherPlacesResult">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -85,4 +85,14 @@
     <dimen name="expandable_section_height">176dp</dimen>
 
     <item name="rating_bar_step_size" format="float" type="dimen">1.0</item>
+
+    <dimen name="contest_result_row_vertical_padding">24dp</dimen>
+    <dimen name="contest_result_card_elevation">8dp</dimen>
+    <dimen name="contest_result_content_horizontal_spacing">12dp</dimen>
+    <dimen name="contest_result_content_vertical_spacing">12dp</dimen>
+    <dimen name="contest_result_entry_score_textsize">18sp</dimen>
+    <dimen name="contest_result_entry_title_textsize">16sp</dimen>
+    <dimen name="contest_result_entry_rank_textsize">14sp</dimen>
+    <dimen name="contest_result_entry_image_width">88dp</dimen>
+    <dimen name="contest_result_entry_image_height">100dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,10 @@
     <string name="default_category_name">Score</string>
     <string name="default_category_description">Overall Submission Score</string>
     <string name="rate_entry_x_out_of_entries">Rate %1$d out of %2$d</string>
+
+    <string name="contest_result_first_place">1st</string>
+    <string name="contest_result_second_place">2nd</string>
+    <string name="contest_result_third_place">3rd</string>
+    <string name="contest_result_other_places"/>
+    <string name="contest_results_no_entries_message">No entries have been submitted.</string>
 </resources>

--- a/app/src/test/java/io/intrepid/contest/screens/contestresults/ContestResultsPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestresults/ContestResultsPresenterTest.java
@@ -1,0 +1,104 @@
+package io.intrepid.contest.screens.contestresults;
+
+import com.jakewharton.retrofit2.adapter.rxjava2.HttpException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import io.intrepid.contest.models.RankedEntryResult;
+import io.intrepid.contest.rest.ContestResultResponse;
+import io.intrepid.contest.testutils.BasePresenterTest;
+import io.reactivex.Observable;
+
+import static io.reactivex.Observable.error;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ContestResultsPresenterTest extends BasePresenterTest<ContestResultsPresenter> {
+    @Mock
+    ContestResultsContract.View mockView;
+
+    @Before
+    public void setup() {
+        presenter = new ContestResultsPresenter(mockView, testConfiguration);
+    }
+
+    @Test
+    public void onViewCreatedShouldHideNoEntriesMessageWhenSuccessfullyRetrievedResultsWithEntries() {
+        setupSuccessfulContestResultsCall(getValidContestResultResponse());
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView).hideNoEntriesMessage();
+    }
+
+    @Test
+    public void onViewCreatedShouldShowResultsWhenSuccessfullyRetrievedResultsWithEntries() {
+        ContestResultResponse resultResponse = getValidContestResultResponse();
+        setupSuccessfulContestResultsCall(resultResponse);
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView).showResults(resultResponse.contestResults.rankedScoredEntries);
+    }
+
+    @Test
+    public void onViewCreatedShouldShowNeverHideNoEntriesMessageWhenSuccessfullyRetrievedResultsWithoutEntries() {
+        setupSuccessfulContestResultsCall(new ContestResultResponse());
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView, never()).hideNoEntriesMessage();
+    }
+
+    @Test
+    public void onViewCreatedShouldShowNeverShowResultsWhenSuccessfullyRetrievedResultsWithoutEntries() {
+        setupSuccessfulContestResultsCall(new ContestResultResponse());
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView, never()).showResults(anyList());
+    }
+
+    @Test
+    public void onViewCreatedShouldShowApiErrorMessageWhenItemIsSendInvitationsAndApiCallThrowsError()
+            throws HttpException {
+        setupUnsuccessfulContestResultsCall();
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView).showMessage(anyInt());
+    }
+
+    private void setupUnsuccessfulContestResultsCall() {
+        when(mockPersistentSettings.getCurrentContestId()).thenReturn(UUID.randomUUID());
+        when(mockRestApi.getContestResults(any())).thenReturn(error(new Throwable()));
+    }
+
+    private void setupSuccessfulContestResultsCall(ContestResultResponse resultResponse) {
+        when(mockPersistentSettings.getCurrentContestId()).thenReturn(UUID.randomUUID());
+        when(mockRestApi.getContestResults(any())).thenReturn(Observable.just(resultResponse));
+    }
+
+    private ContestResultResponse getValidContestResultResponse() {
+        List<RankedEntryResult> rankedScoredEntries = new ArrayList<>();
+        rankedScoredEntries.add(new RankedEntryResult());
+        rankedScoredEntries.add(new RankedEntryResult());
+        rankedScoredEntries.add(new RankedEntryResult());
+        return new ContestResultResponse(rankedScoredEntries);
+    }
+}


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-211

- Includes hooking it up to contest status: https://intrepid.atlassian.net/browse/CON-213
- Does not include displaying the score details: https://intrepid.atlassian.net/browse/CON-212

I did add some unused fields in my pojos, but I just wanted to make sure they were being retrieved from the API. They will be used in the next subtask (CON-212). I can remove them if you think it's a bad idea to have them merged in now.