### PR TITLE
CON-217: Skip inviting contestants update app bar title

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsActivity.java
@@ -57,7 +57,7 @@ public class SendInvitationsActivity extends BaseMvpActivity<SendInvitationsCont
 
     @Override
     public ParticipationType getParticipationType() {
-        return presenter.getParticipationType();
+        return presenter.getInvitationParticipantType();
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsContract.java
@@ -52,6 +52,6 @@ class SendInvitationsContract {
 
         boolean hasContactPermissions();
 
-        ParticipationType getParticipationType();
+        ParticipationType getInvitationParticipantType();
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenter.java
@@ -25,7 +25,7 @@ class SendInvitationsPresenter extends BasePresenter<SendInvitationsContract.Vie
     private SendInvitationsContent lastShowed;
     private boolean contactSelectionEnabled = false;
     private boolean displayMenuItemsAndActionBar = true;
-    private ParticipationType participationType;
+    private ParticipationType invitationParticipantType;
 
     SendInvitationsPresenter(@NonNull SendInvitationsContract.View view,
                              @NonNull PresenterConfiguration configuration) {
@@ -54,15 +54,14 @@ class SendInvitationsPresenter extends BasePresenter<SendInvitationsContract.Vie
         return view.checkContactsPermissions();
     }
 
-    @Override
-    public ParticipationType getParticipationType() {
-        return participationType;
+    public ParticipationType getInvitationParticipantType() {
+        return invitationParticipantType;
     }
 
     @Override
     public void onViewCreated() {
         super.onViewCreated();
-        participationType = ParticipationType.CONTESTANT;
+        invitationParticipantType = ParticipationType.CONTESTANT;
         showPreviewContent();
     }
 
@@ -152,11 +151,13 @@ class SendInvitationsPresenter extends BasePresenter<SendInvitationsContract.Vie
     }
 
     private void showNextScreen() {
-        switch (participationType) {
+        // Screen to display after inviting participants of this type
+        switch (invitationParticipantType) {
             case CONTESTANT:
-                participationType = ParticipationType.JUDGE;
+                invitationParticipantType = ParticipationType.JUDGE;
                 selectedContactList.clear();
                 showPreviewContent();
+                updateMenuItemsAndActionBar();
                 break;
             case JUDGE:
                 view.showContestStatusScreen();
@@ -173,7 +174,8 @@ class SendInvitationsPresenter extends BasePresenter<SendInvitationsContract.Vie
 
         String contestId = persistentSettings.getCurrentContestId().toString();
         BatchInviteRequest batchInviteRequest = new BatchInviteRequest();
-        batchInviteRequest.invitations = new InvitationRequest(contestId, participationType, selectedContactList);
+        batchInviteRequest.invitations = new InvitationRequest(contestId,
+                                                               invitationParticipantType, selectedContactList);
 
         Disposable disposable = restApi.batchInvite(contestId, batchInviteRequest)
                 .compose(subscribeOnIoObserveOnUi())
@@ -201,7 +203,7 @@ class SendInvitationsPresenter extends BasePresenter<SendInvitationsContract.Vie
 
     private void updateMenuItemsAndActionBar() {
         if (displayMenuItemsAndActionBar) {
-            view.setActionBarTitle(participationType.equals(ParticipationType.CONTESTANT) ?
+            view.setActionBarTitle(invitationParticipantType.equals(ParticipationType.CONTESTANT) ?
                                            R.string.invite_contestants_bar_title : R.string.invite_judges_bar_title);
             view.setActionBarDisplayHomeAsUpEnabled(false);
             view.showSendInvitationsMenuItem(!selectedContactList.isEmpty());

--- a/app/src/test/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/sendinvitations/SendInvitationsPresenterTest.java
@@ -134,13 +134,13 @@ public class SendInvitationsPresenterTest extends BasePresenterTest<SendInvitati
     @Test
     public void getParticipationTypeShouldReturnContestantWhenViewIsShowingContestants() {
         setParticipationType(ParticipationType.CONTESTANT);
-        assertEquals(ParticipationType.CONTESTANT, presenter.getParticipationType());
+        assertEquals(ParticipationType.CONTESTANT, presenter.getInvitationParticipantType());
     }
 
     @Test
     public void getParticipationTypeShouldReturnJudgeWhenViewIsShowingJudges() {
         setParticipationType(ParticipationType.JUDGE);
-        assertEquals(ParticipationType.JUDGE, presenter.getParticipationType());
+        assertEquals(ParticipationType.JUDGE, presenter.getInvitationParticipantType());
     }
 
     @Test
@@ -301,7 +301,14 @@ public class SendInvitationsPresenterTest extends BasePresenterTest<SendInvitati
     public void onOptionsItemSelectedShouldSetParticipationJudgeWhenItemIsSendInvitationsSkipInvitingContestants() {
         setParticipationType(ParticipationType.CONTESTANT);
         presenter.onOptionsItemSelected(R.id.send_invitations_skip_menu_action);
-        assertEquals(ParticipationType.JUDGE, presenter.getParticipationType());
+        assertEquals(ParticipationType.JUDGE, presenter.getInvitationParticipantType());
+    }
+
+    @Test
+    public void onOptionsItemSelectedShouldSetJudgeActionBarTitleWhenSkipInvitingContestants() {
+        setParticipationType(ParticipationType.CONTESTANT);
+        presenter.onOptionsItemSelected(R.id.send_invitations_skip_menu_action);
+        verify(mockView).setActionBarTitle(R.string.invite_judges_bar_title);
     }
 
     @Test
@@ -325,7 +332,7 @@ public class SendInvitationsPresenterTest extends BasePresenterTest<SendInvitati
         presenter.onOptionsItemSelected(R.id.send_invitations_menu_action);
         testConfiguration.triggerRxSchedulers();
 
-        assertEquals(ParticipationType.JUDGE, presenter.getParticipationType());
+        assertEquals(ParticipationType.JUDGE, presenter.getInvitationParticipantType());
     }
 
     @Test


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-217

- Skip inviting contestants now updates app bar title (`onCreateOptionsMenu()` was never called after refectoring of activity)
- Also changes the name of the variable `participationType` because that raised confusion about whether it was changing the participationType of the current user, or indicating which type of user was being invited in the screen