### PR TITLE
Support contest status for judge flow

### DIFF
--- a/app/src/main/java/io/intrepid/contest/base/BaseActivity.java
+++ b/app/src/main/java/io/intrepid/contest/base/BaseActivity.java
@@ -12,7 +12,6 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import butterknife.ButterKnife;
-import io.intrepid.contest.BuildConfig;
 import io.intrepid.contest.ContestApplication;
 import io.intrepid.contest.screens.splash.SplashActivity;
 import io.intrepid.contest.utils.ShakeDetector;
@@ -137,9 +136,7 @@ abstract class BaseActivity extends AppCompatActivity {
     }
 
     public void showMessage(String message) {
-        if (BuildConfig.DEV_BUILD) {
-            Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
-        }
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
     }
 
     public void showMessage(@StringRes int messageResource) {

--- a/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/MockRestApi.java
@@ -21,7 +21,7 @@ import retrofit2.Response;
 import retrofit2.http.Body;
 import retrofit2.http.Path;
 
-public class MockRestApi implements RestApi {
+class MockRestApi implements RestApi {
     private static final String TEST_JUDGE_CODE = "judge";
     private static final String TEST_ENTRY_IMAGE = "https://www.chowstatic.com/assets/2014/09/30669_spicy_slow_cooker_beef_chili_3000x2000.jpg";
 
@@ -31,7 +31,7 @@ public class MockRestApi implements RestApi {
     private String contestDescription;
     private int numGetContestStatusCallsForParticipant;
 
-    public MockRestApi() {
+    MockRestApi() {
         userId = UUID.randomUUID();
         contestId = UUID.randomUUID();
         contestTitle = "Contest title";
@@ -94,6 +94,12 @@ public class MockRestApi implements RestApi {
             return Observable.just(getValidRedeemInvitationResponse(ParticipationType.JUDGE));
         }
         return Observable.just(getValidRedeemInvitationResponse(ParticipationType.CONTESTANT));
+    }
+
+    public Observable<ContestWrapper> endContest(String id) {
+        Contest contest = new Contest();
+        contest.setId(UUID.fromString(id));
+        return Observable.just(new ContestWrapper(contest));
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/rest/RestApi.java
+++ b/app/src/main/java/io/intrepid/contest/rest/RestApi.java
@@ -20,6 +20,9 @@ public interface RestApi {
     Observable<RedeemInvitationResponse> redeemInvitationCode(@Path("code") String code,
                                                               @Body RedeemInvitationRequest redeemInvitationRequest);
 
+    @PATCH("api/admin/contests/{id}/end")
+    Observable<ContestWrapper> endContest(String id);
+
     @POST("api/contests")
     Observable<ContestWrapper> submitContest(@Body ContestWrapper contest);
 

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -101,6 +101,7 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
     }
 
     private void onApiResult(ContestWrapper response) {
+        Timber.d("Contest id " + response.contest.getId());
         persistentSettings.setCurrentContestId(response.contest.getId());
         view.navigateToSendInvitationsScreen();
     }

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenter.java
@@ -8,7 +8,6 @@ import io.intrepid.contest.BuildConfig;
 import io.intrepid.contest.R;
 import io.intrepid.contest.base.BasePresenter;
 import io.intrepid.contest.base.PresenterConfiguration;
-import io.intrepid.contest.models.ParticipationType;
 import io.intrepid.contest.rest.ContestStatusResponse;
 import io.intrepid.contest.rest.ContestWrapper;
 import io.reactivex.Observable;
@@ -60,16 +59,15 @@ class ContestStatusPresenter extends BasePresenter<ContestStatusContract.View> i
         if (response.contestStatus.hasContestEnded()) {
             view.showResultsAvailableFragment();
             disposables.clear();
-            return;
+        } else {
+            switch (persistentSettings.getCurrentParticipationType()) {
+                case JUDGE:
+                    view.showContestOverviewPage();
+                    break;
+                default:
+                    view.showStatusWaitingFragment();
+            }
         }
-
-        if (!response.contestStatus.haveSubmissionsEnded() ||
-                (persistentSettings.getCurrentParticipationType() != ParticipationType.JUDGE)) {
-            view.showStatusWaitingFragment();
-            return;
-        }
-
-        view.showContestOverviewPage();
     }
 
     @Override

--- a/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
@@ -60,7 +60,7 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     private void getContestStatusResponseWaitingForScores() {
         ContestStatusResponse response = new ContestStatusResponse();
         response.contestStatus = new ContestStatus();
-        response.contestStatus.setSubmissionData(true, 5, 5);
+        response.contestStatus.setSubmissionData(false, 5, 5);
         response.contestStatus.setJudgeData(false, 0, 1);
         when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
     }
@@ -76,6 +76,7 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @Test
     public void onViewCreatedShouldShowStatusWaitingFragmentWhenStatusIsWaitingForSubmissions() {
         getContestStatusResponseWaitingForSubmissions();
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.CONTESTANT);
 
         presenter.onViewCreated();
         testConfiguration.triggerRxSchedulers();
@@ -87,8 +88,9 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
 
     @Test
     public void onViewCreatedShouldShowStatusWaitingFragmentWhenWaitingForScoresAndParticipantIsContestant() {
-        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.CONTESTANT);
         getContestStatusResponseWaitingForScores();
+
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.CONTESTANT);
 
         presenter.onViewCreated();
         testConfiguration.triggerRxSchedulers();
@@ -126,12 +128,25 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @Test
     public void onViewCreatedShouldRefreshWaitingSubmissionsFragmentPeriodically() {
         getContestStatusResponseWaitingForSubmissions();
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.CONTESTANT);
 
         presenter.onViewCreated();
         testConfiguration.getIoScheduler().advanceTimeBy(API_CALL_INTERVAL, API_CALL_INTERVAL_UNIT);
         testConfiguration.triggerRxSchedulers();
 
         verify(mockView, times(2)).showStatusWaitingFragment();
+    }
+
+    @Test
+    public void onViewCreatedShouldRefreshOverviewPageWhenParticipationTypeIsJudge() {
+        getContestStatusResponseWaitingForSubmissions();
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.JUDGE);
+
+        presenter.onViewCreated();
+        testConfiguration.getIoScheduler().advanceTimeBy(API_CALL_INTERVAL, API_CALL_INTERVAL_UNIT);
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView, times(2)).showContestOverviewPage();
     }
 
     @Test


### PR DESCRIPTION
 When contest has already ended, screen for judges should show contest status rather than an overview.

 This was initially tested with Postman, by creating a user in postman, creating a contest, inviting a judge and thenjoining the app as a judge before ending the contest in postman.

Changing the order of this does not ensure the same results though:  Ending the contest before attempting to join as a judge with the code appears to be registered by the api as a regular contestant code instead.