### PR TITLE
Con 233 - After judging, show Wait Screen or Results

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/contestjudging/scoreentries/entrieslist/EntriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestjudging/scoreentries/entrieslist/EntriesListFragment.java
@@ -94,6 +94,6 @@ public class EntriesListFragment extends BaseFragment<EntriesListContract.Presen
 
     @Override
     public void showContestStatusScreen() {
-        startActivity(ContestStatusActivity.makeIntent(getActivity()));
+        startActivity(ContestStatusActivity.makeIntent(getActivity(), true));
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusActivity.java
+++ b/app/src/main/java/io/intrepid/contest/screens/conteststatus/ContestStatusActivity.java
@@ -19,6 +19,12 @@ import io.reactivex.functions.Consumer;
 public class ContestStatusActivity extends BaseMvpActivity<ContestStatusContract.Presenter>
         implements ContestStatusContract.View, ContestStatusActivityContract {
 
+    private static final String JUDGE_JUST_SUBMITTED_KEY = "judge_submitted_key";
+
+    public static Intent makeIntent(Context context, boolean judgeSubmitted) {
+        return makeIntent(context).putExtra(JUDGE_JUST_SUBMITTED_KEY, judgeSubmitted);
+    }
+
     public static Intent makeIntent(Context context) {
         return new Intent(context, ContestStatusActivity.class);
     }
@@ -26,7 +32,8 @@ public class ContestStatusActivity extends BaseMvpActivity<ContestStatusContract
     @NonNull
     @Override
     public ContestStatusContract.Presenter createPresenter(PresenterConfiguration configuration) {
-        return new ContestStatusPresenter(this, configuration);
+        boolean recentlySubmittedAsJudge = getIntent().getBooleanExtra(JUDGE_JUST_SUBMITTED_KEY, false);
+        return new ContestStatusPresenter(this, configuration, recentlySubmittedAsJudge);
     }
 
     @Override

--- a/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/conteststatus/ContestStatusPresenterTest.java
@@ -44,7 +44,7 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
     @Before
     public void setup() {
         throwable = new Throwable();
-        presenter = new ContestStatusPresenter(mockView, testConfiguration);
+        presenter = new ContestStatusPresenter(mockView, testConfiguration, false);
 
         when(mockPersistentSettings.getCurrentContestId()).thenReturn(UUID.randomUUID());
     }
@@ -71,6 +71,41 @@ public class ContestStatusPresenterTest extends BasePresenterTest<ContestStatusP
         response.contestStatus.setSubmissionData(true, 5, 5);
         response.contestStatus.setJudgeData(true, 1, 1);
         when(mockRestApi.getContestStatus(any())).thenReturn(Observable.just(response));
+    }
+
+    @Test
+    public void onViewCreatedShouldShowAdminStatusPageIfParticipationTypeIsCreator() {
+        getContestStatusResponseWaitingForSubmissions();
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.CREATOR);
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView).showAdminStatusPage();
+    }
+
+    @Test
+    public void onViewCreatedShouldShowResultsWhenJudgeHasSubmittedScoreAndResultsAreAvailable() {
+        getContestStatusResponseResultsAvailable();
+        presenter = new ContestStatusPresenter(mockView, testConfiguration, true);
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.JUDGE);
+
+        presenter.onViewCreated();
+        testConfiguration.triggerRxSchedulers();
+
+        verify(mockView).showResultsAvailableFragment();
+    }
+
+    @Test
+    public void onViewCreatedShouldShowStatusWaitingFragmentIfJudgeJustVoted() {
+        getContestStatusResponseWaitingForScores();
+        when(mockPersistentSettings.getCurrentParticipationType()).thenReturn(ParticipationType.JUDGE);
+
+        presenter = new ContestStatusPresenter(mockView, testConfiguration, true);
+        presenter.onViewCreated();
+
+        testConfiguration.triggerRxSchedulers();
+        verify(mockView).showStatusWaitingFragment();
     }
 
     @Test


### PR DESCRIPTION
Judge Flow should show wait screen or results depending on contest status

* API does not support identifying the judges participating in this contest. This uses an intent extra instead to indicate whether or not judge participant just submitted a score. This is one approach for determining if the current user just submitted scores given that we cannot query the api for this information.