### PR TITLE
Fix entry submission without an image

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
@@ -61,7 +61,12 @@ class EntryImagePresenter extends BasePresenter<EntryImageContract.View> impleme
     public void onEntrySubmitted() {
         Timber.d("Entry creation API call.");
         String contestId = persistentSettings.getCurrentContestId().toString();
-        Bitmap bitmap = view.makeBitmap(croppedUri);
+
+        Bitmap bitmap = null;
+        if (croppedUri != null) {
+            bitmap = view.makeBitmap(croppedUri);
+        }
+
         EntryRequest entryRequest = new EntryRequest(entryName,
                                                      bitmap,
                                                      FORMAT_PREFIX,

--- a/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
@@ -1,6 +1,5 @@
 package io.intrepid.contest.screens.entrysubmission.entryimage;
 
-import android.graphics.Bitmap;
 import android.net.Uri;
 
 import com.jakewharton.retrofit2.adapter.rxjava2.HttpException;
@@ -24,7 +23,6 @@ import static io.reactivex.Observable.error;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -65,8 +63,6 @@ public class EntryImagePresenterTest extends BasePresenterTest<EntryImagePresent
 
     @Test
     public void bindingViewShouldStartCropImageLayoutWhenBitmapWasReceived() {
-        Bitmap mockBitmap = mock(Bitmap.class);
-
         presenter.onImageReceived(mockUri);
         presenter.bindView(mockView);
 
@@ -92,6 +88,17 @@ public class EntryImagePresenterTest extends BasePresenterTest<EntryImagePresent
     public void onGalleryButtonClickedShouldDispatchChoosePictureIntent() {
         presenter.onGalleryButtonClicked();
         verify(mockView).dispatchChoosePictureIntent();
+    }
+
+    @Test
+    public void onEntrySubmittedShouldCreateBitmapWhenImageHasBeenSelectedAndCropped() {
+        when(mockPersistentSettings.getCurrentContestId()).thenReturn(UUID.randomUUID());
+        when(mockRestApi.createEntry(any(), any())).thenReturn(error(throwable));
+        presenter.onImageCropped(mockUri);
+
+        presenter.onEntrySubmitted();
+
+        verify(mockView).makeBitmap(mockUri);
     }
 
     @Test


### PR DESCRIPTION
Entry submission always expected a `croppedUri`, breaking when the user selected "No, thanks" to sending an image.