### PR TITLE
Use Transition Framework Scenes in EntryImageActivity

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImageContract.java
@@ -9,9 +9,7 @@ class EntryImageContract {
     interface View extends BaseContract.View {
         String getEntryName();
 
-        void showEntryName(String entryName);
-
-        void displayChooseImageLayout();
+        void displayChooseImageLayout(String entryName);
 
         void startCropImage(String entryName, Uri uri);
 
@@ -27,7 +25,7 @@ class EntryImageContract {
 
         void requestStoragePermissions();
 
-        void displayPreviewImageLayout(Uri croppedUri);
+        void displayPreviewImageLayout(String entryName, Uri croppedUri);
 
         Bitmap makeBitmap(Uri croppedUri);
     }

--- a/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenter.java
@@ -34,21 +34,20 @@ class EntryImagePresenter extends BasePresenter<EntryImageContract.View> impleme
     public void onViewCreated() {
         super.onViewCreated();
         entryName = view.getEntryName();
-        view.showEntryName(entryName);
-        view.displayChooseImageLayout();
+        view.displayChooseImageLayout(entryName);
     }
 
     @Override
     protected void onViewBound() {
         super.onViewBound();
         if (croppedUri != null) {
-            view.displayPreviewImageLayout(croppedUri);
+            view.displayPreviewImageLayout(entryName, croppedUri);
         } else if (imageUri != null) {
             view.checkStoragePermissions();
             view.startCropImage(entryName, imageUri);
             Timber.d("Starting crop");
         } else {
-            view.displayChooseImageLayout();
+            view.displayChooseImageLayout(entryName);
         }
     }
 
@@ -96,7 +95,7 @@ class EntryImagePresenter extends BasePresenter<EntryImageContract.View> impleme
     public void onBitmapRemoved() {
         imageUri = null;
         croppedUri = null;
-        view.displayChooseImageLayout();
+        view.displayChooseImageLayout(entryName);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_entry_image.xml
+++ b/app/src/main/res/layout/activity_entry_image.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_entry_image"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -13,112 +12,12 @@
         android:text="@string/common_submit"
         />
 
-    <android.support.percent.PercentRelativeLayout
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/entry_choose_image_layout"
+    <FrameLayout
+        android:id="@+id/entry_image_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@id/entry_image_submit_button"
         android:layout_alignParentTop="true"
-        android:paddingBottom="@dimen/entry_submit_image_padding_bottom"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:visibility="invisible"
-        tools:visibility="visible"
-        >
-
-        <TextView
-            android:id="@+id/entry_image_question_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="@style/AvenirNext_Medium"
-            android:text="@string/entry_image_question"
-            android:textColor="@color/colorEntrySubmitImageTitle"
-            android:textSize="@dimen/entry_submit_image_title_textsize"
-            />
-
-        <TextView
-            android:id="@+id/entry_image_description_text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/entry_image_question_text_view"
-            android:layout_marginBottom="@dimen/activity_vertical_margin"
-            android:text="@string/entry_image_description"
-            android:textColor="@color/colorEntrySubmitImageDescription"
-            android:textSize="@dimen/entry_submit_image_description_textsize"
-            />
-
-        <android.support.v7.widget.CardView
-            android:id="@+id/entry_image_camera_button_card_view"
-            style="@style/AppTheme.IconButtonCardView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            app:layout_widthPercent="48%"
-            >
-
-            <Button
-                android:id="@+id/entry_image_camera_button"
-                style="@style/AppTheme.IconButton"
-                android:drawableTop="@drawable/camera_icon"
-                android:text="@string/upload_image_camera"
-                />
-
-        </android.support.v7.widget.CardView>
-
-        <android.support.v7.widget.CardView
-            android:id="@+id/entry_image_gallery_button_card_view"
-            style="@style/AppTheme.IconButtonCardView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            app:layout_widthPercent="48%"
-            >
-
-            <Button
-                android:id="@+id/entry_image_gallery_button"
-                style="@style/AppTheme.IconButton"
-                android:drawableTop="@drawable/gallery_icon"
-                android:text="@string/upload_image_library"
-                />
-
-        </android.support.v7.widget.CardView>
-
-    </android.support.percent.PercentRelativeLayout>
-
-    <RelativeLayout
-        android:id="@+id/entry_preview_image_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_above="@id/entry_image_submit_button"
-        android:layout_alignParentTop="true"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:visibility="invisible"
-        tools:visibility="visible"
-        >
-
-        <TextView
-            android:id="@+id/entry_preview_label_text_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:gravity="center"
-            android:text="@string/entry_image_preview_caption"
-            />
-
-        <io.intrepid.contest.customviews.RemovableImageFrameLayout
-            android:id="@+id/entry_preview_image"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_above="@id/entry_preview_label_text_view"
-            />
-
-    </RelativeLayout>
+        />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/entry_image_choose_layout.xml
+++ b/app/src/main/res/layout/entry_image_choose_layout.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+    <android.support.percent.PercentRelativeLayout
+        android:id="@+id/entry_choose_image_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="@dimen/entry_submit_image_padding_bottom"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        >
+
+        <TextView
+            android:id="@+id/entry_image_question_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@style/AvenirNext_Medium"
+            android:text="@string/entry_image_question"
+            android:textColor="@color/colorEntrySubmitImageTitle"
+            android:textSize="@dimen/entry_submit_image_title_textsize"
+            />
+
+        <TextView
+            android:id="@+id/entry_image_description_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/entry_image_question_text_view"
+            android:layout_marginBottom="@dimen/activity_vertical_margin"
+            android:text="@string/entry_image_description"
+            android:textColor="@color/colorEntrySubmitImageDescription"
+            android:textSize="@dimen/entry_submit_image_description_textsize"
+            />
+
+        <android.support.v7.widget.CardView
+            android:id="@+id/entry_image_camera_button_card_view"
+            style="@style/AppTheme.IconButtonCardView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            app:layout_widthPercent="48%"
+            >
+
+            <Button
+                android:id="@+id/entry_image_camera_button"
+                style="@style/AppTheme.IconButton"
+                android:drawableTop="@drawable/camera_icon"
+                android:text="@string/upload_image_camera"
+                />
+
+        </android.support.v7.widget.CardView>
+
+        <android.support.v7.widget.CardView
+            android:id="@+id/entry_image_gallery_button_card_view"
+            style="@style/AppTheme.IconButtonCardView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            app:layout_widthPercent="48%"
+            >
+
+            <Button
+                android:id="@+id/entry_image_gallery_button"
+                style="@style/AppTheme.IconButton"
+                android:drawableTop="@drawable/gallery_icon"
+                android:text="@string/upload_image_library"
+                />
+
+        </android.support.v7.widget.CardView>
+
+    </android.support.percent.PercentRelativeLayout>
+</merge>

--- a/app/src/main/res/layout/entry_image_preview_layout.xml
+++ b/app/src/main/res/layout/entry_image_preview_layout.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/entry_preview_image_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    >
+
+    <TextView
+        android:id="@+id/entry_preview_label_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:gravity="center"
+        android:text="@string/entry_image_preview_caption"
+        />
+
+    <io.intrepid.contest.customviews.RemovableImageFrameLayout
+        android:id="@+id/entry_preview_image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/entry_preview_label_text_view"
+        />
+
+</RelativeLayout>

--- a/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/entrysubmission/entryimage/EntryImagePresenterTest.java
@@ -8,7 +8,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.UUID;
@@ -35,47 +34,49 @@ public class EntryImagePresenterTest extends BasePresenterTest<EntryImagePresent
     @Mock
     Uri mockUri;
     private Throwable throwable;
+    private String entryName;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        entryName = "Entry Name";
+        when(mockView.getEntryName()).thenReturn(entryName);
+
         throwable = new Throwable();
         presenter = new EntryImagePresenter(mockView, testConfiguration);
     }
 
     @Test
-    public void onViewCreatedPreviewLabelShouldShowEntryName() {
-        presenter.onViewCreated();
-        verify(mockView).showEntryName(any());
-    }
-
-    @Test
     public void onBitmapRemovedShouldDisplayChooseImageLayout() {
+        presenter.onViewCreated();
+        reset(mockView);
+
         presenter.onBitmapRemoved();
-        verify(mockView).displayChooseImageLayout();
+
+        verify(mockView).displayChooseImageLayout(entryName);
     }
 
     @Test
     public void onViewCreatedShouldDisplayChooseImageLayoutWhenBitmapsHaveNeverBeenReceived() {
         presenter.onViewCreated();
-        verify(mockView).displayChooseImageLayout();
+        verify(mockView).displayChooseImageLayout(entryName);
     }
 
     @Test
     public void bindingViewShouldStartCropImageLayoutWhenBitmapWasReceived() {
         presenter.onImageReceived(mockUri);
-        presenter.bindView(mockView);
-
+        presenter.onViewBound();
         verify(mockView).startCropImage(any(), eq(mockUri));
     }
 
     @Test
     public void bindingViewShouldDisplayChooseImageLayoutWhenBitmapWasRemoved() {
+        presenter.onViewCreated();
         presenter.onBitmapRemoved();
         reset(mockView);
-        presenter.bindView(mockView);
 
-        verify(mockView).displayChooseImageLayout();
+        presenter.onViewBound();
+
+        verify(mockView).displayChooseImageLayout(entryName);
     }
 
     @Test
@@ -146,9 +147,12 @@ public class EntryImagePresenterTest extends BasePresenterTest<EntryImagePresent
 
     @Test
     public void onImageCroppedShouldCauseViewToPreviewCroppedImageAfterNextViewBind() {
+        presenter.onViewCreated();
         presenter.onImageCropped(mockUri);
+
         presenter.onViewBound();
-        verify(mockView).displayPreviewImageLayout(mockUri);
+
+        verify(mockView).displayPreviewImageLayout(entryName, mockUri);
     }
 
     @Test
@@ -156,5 +160,4 @@ public class EntryImagePresenterTest extends BasePresenterTest<EntryImagePresent
         presenter.onImageCropped(null);
         verify(mockView).showMessage(anyInt());
     }
-
 }


### PR DESCRIPTION
- Instead of showing/hiding layout in the main layout xml, transition between 2 scenes (each one created form a layout)

- Advantage of this approach:
   - Cleaner code
   - Easy animation effect

- Disadvantages:
   - Layout elements have to be inflated every time there is a transition (but it's not expected that this will happen many times)


- The Butterknife binding is not straightforward with elements being inflated in the layout later. [The first commit](https://github.com/IntrepidPursuits/ContestAndroid/commit/048ddc71b99feb88c04da63300529e3364164b11) has one approach (binding happens in the activity's code), and [the second](https://github.com/IntrepidPursuits/ContestAndroid/commit/38480a55c469ea99aa12a55c6de82d4a8aa2df77) has another (binding happens in another class, as [suggested by Jake Wharton for one - simpler - example](https://github.com/JakeWharton/butterknife/issues/414)). I thought the second approach encapsulated better the elements from each view, but it's not straightforward to understand what happens when the object is created.