### PR TITLE
CON-239: Fix accessing previous contest as creator

### DIFF
--- a/app/src/main/java/io/intrepid/contest/screens/splash/SplashPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/splash/SplashPresenter.java
@@ -70,7 +70,9 @@ class SplashPresenter extends BasePresenter<SplashContract.View> implements Spla
     @Override
     public void onContestClicked(Contest contest) {
         persistentSettings.setCurrentContestId(contest.getId());
-        persistentSettings.setCurrentParticipationType(contest.getParticipationType());
+        ParticipationType participationType = contest.getParticipationType();
+        persistentSettings.setCurrentParticipationType(
+                participationType == null ? ParticipationType.CREATOR : participationType);
         view.resumeContest(contest);
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/splash/SplashPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/splash/SplashPresenterTest.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import io.intrepid.contest.R;
 import io.intrepid.contest.models.ActiveContestListResponse;
 import io.intrepid.contest.models.Contest;
+import io.intrepid.contest.models.ParticipationType;
 import io.intrepid.contest.models.User;
 import io.intrepid.contest.rest.UserCreationResponse;
 import io.intrepid.contest.testutils.BasePresenterTest;
@@ -135,5 +136,35 @@ public class SplashPresenterTest extends BasePresenterTest<SplashPresenter> {
     public void onContestClickedShouldCauseViewToResumeContest() {
         presenter.onContestClicked(mockContest);
         verify(mockView).resumeContest(mockContest);
+    }
+
+    @Test
+    public void onContestClickedShouldSaveParticipationTypeAsCreatorWhenApiParticipationIsNull() {
+        when(mockContest.getId()).thenReturn(UUID.randomUUID());
+        when(mockContest.getParticipationType()).thenReturn(null);
+
+        presenter.onContestClicked(mockContest);
+
+        verify(mockPersistentSettings).setCurrentParticipationType(ParticipationType.CREATOR);
+    }
+
+    @Test
+    public void onContestClickedShouldSaveParticipationTypeAsContestantWhenApiParticipationIsContestant() {
+        when(mockContest.getId()).thenReturn(UUID.randomUUID());
+        when(mockContest.getParticipationType()).thenReturn(ParticipationType.CONTESTANT);
+
+        presenter.onContestClicked(mockContest);
+
+        verify(mockPersistentSettings).setCurrentParticipationType(ParticipationType.CONTESTANT);
+    }
+
+    @Test
+    public void onContestClickedShouldSaveParticipationTypeAsJudgeWhenApiParticipationIsJudge() {
+        when(mockContest.getId()).thenReturn(UUID.randomUUID());
+        when(mockContest.getParticipationType()).thenReturn(ParticipationType.JUDGE);
+
+        presenter.onContestClicked(mockContest);
+
+        verify(mockPersistentSettings).setCurrentParticipationType(ParticipationType.JUDGE);
     }
 }


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-239

Currently the API returns `participationType` as `null` if the user was a creator of the contest.