### PR TITLE
CON-242: Apply category reordering

### DIFF
--- a/app/src/main/java/io/intrepid/contest/models/Contest.java
+++ b/app/src/main/java/io/intrepid/contest/models/Contest.java
@@ -98,12 +98,12 @@ public class Contest {
         this.submissionsClosedAt = submissionsClosedAt;
     }
 
-    public void setParticipationType(ParticipationType participationType) {
-        this.participationType = participationType;
-    }
-
     public ParticipationType getParticipationType() {
         return participationType;
+    }
+
+    public void setParticipationType(ParticipationType participationType) {
+        this.participationType = participationType;
     }
 
     public static class Builder {
@@ -164,11 +164,6 @@ public class Contest {
 
         public List<Category> getCategories() {
             return categories;
-        }
-
-        public Builder setCategories(List<Category> categories) {
-            this.categories = categories;
-            return this;
         }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ContestCreationFragment.java
@@ -1,6 +1,5 @@
 package io.intrepid.contest.screens.contestcreation;
 
-public interface ContestCreationFragment{
-
+public interface ContestCreationFragment {
     void onNextClicked();
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -11,6 +11,7 @@ import io.intrepid.contest.base.PresenterConfiguration;
 import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.rest.ContestWrapper;
+import io.intrepid.contest.screens.contestcreation.reviewcontest.ReviewContestFragment;
 import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
@@ -106,14 +107,14 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-        onPageSelected(position);
+        // Do nothing
     }
 
     @Override
     public void onPageSelected(int position) {
-        if (view.getChildEditFragment(position) instanceof ValidatableContestCreationFragment) {
-            ValidatableContestCreationFragment fragment = (ValidatableContestCreationFragment) view.getChildEditFragment(
-                    position);
+        ContestCreationFragment childEditFragment = view.getChildEditFragment(position);
+        if (childEditFragment instanceof ValidatableContestCreationFragment) {
+            ValidatableContestCreationFragment fragment = (ValidatableContestCreationFragment) childEditFragment;
             fragment.onFocus();
         }
 
@@ -132,11 +133,14 @@ class NewContestPresenter extends BasePresenter<NewContestMvpContract.View> impl
                 pageTitle = R.string.new_contest;
         }
         view.setPageTitle(pageTitle);
+
+        if (childEditFragment instanceof ReviewContestFragment) {
+            ((ReviewContestFragment) childEditFragment).onPageSelected();
+        }
     }
 
     @Override
     public void onPageScrollStateChanged(int state) {
-        int position = view.getCurrentIndex();
-        onPageSelected(position);
+        // Do nothing
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
@@ -25,7 +25,7 @@ interface CategoriesListContract {
     interface Presenter extends BaseContract.Presenter<ContestCreationFragment>, CategoryClickListener {
         void displayCategories();
 
-        void onNextClicked(List<Category> categories);
+        void onNextClicked();
 
         void onAddCategoryClicked();
     }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -56,7 +56,7 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
 
     @Override
     public void onNextClicked() {
-        presenter.onNextClicked(categoryAdapter.getCategories());
+        presenter.onNextClicked();
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
@@ -3,6 +3,7 @@ package io.intrepid.contest.screens.contestcreation.categorieslist;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.intrepid.contest.R;
@@ -13,21 +14,19 @@ import io.intrepid.contest.models.Contest;
 
 class CategoriesListPresenter extends BasePresenter<CategoriesListContract.ContestCreationFragment> implements CategoriesListContract.Presenter {
     private final Contest.Builder contestBuilder;
-    private List<Category> categories;
 
     CategoriesListPresenter(@NonNull CategoriesListContract.ContestCreationFragment view,
                             @NonNull PresenterConfiguration configuration,
                             Contest.Builder contestBuilder) {
         super(view, configuration);
         this.contestBuilder = contestBuilder;
-        categories = this.contestBuilder.getCategories();
+        List<Category> categories = this.contestBuilder.getCategories();
         categories = categories == null ? new ArrayList<>() : categories;
 
         if (categories.isEmpty()) {
             Category defaultCategory = view.getDefaultCategory(R.string.default_category_name,
                                                                R.string.default_category_description);
             categories.add(defaultCategory);
-            this.contestBuilder.setCategories(categories);
         }
     }
 
@@ -49,8 +48,7 @@ class CategoriesListPresenter extends BasePresenter<CategoriesListContract.Conte
     }
 
     @Override
-    public void onNextClicked(List<Category> categories) {
-        contestBuilder.setCategories(categories);
+    public void onNextClicked() {
         view.showNextScreen();
     }
 
@@ -61,7 +59,7 @@ class CategoriesListPresenter extends BasePresenter<CategoriesListContract.Conte
 
     @Override
     public void onCategoryClicked(Category category) {
-        view.showEditCategoryPage(category, categories.indexOf(category));
+        view.showEditCategoryPage(category, contestBuilder.getCategories().indexOf(category));
     }
 
     @Override
@@ -74,5 +72,19 @@ class CategoriesListPresenter extends BasePresenter<CategoriesListContract.Conte
     private void determineNextIconVisibility() {
         boolean nextEnabled = !contestBuilder.getCategories().isEmpty();
         view.setNextEnabled(nextEnabled);
+    }
+
+    @Override
+    public void onCategoryMoved(int fromPosition, int toPosition) {
+        List<Category> categories = contestBuilder.getCategories();
+        if (fromPosition < toPosition) {
+            for (int i = fromPosition; i < toPosition; i++) {
+                Collections.swap(categories, i, i + 1);
+            }
+        } else {
+            for (int i = fromPosition; i > toPosition; i--) {
+                Collections.swap(categories, i, i - 1);
+            }
+        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoryAdapter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoryAdapter.java
@@ -5,7 +5,6 @@ import android.support.v7.widget.RecyclerView;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import io.intrepid.contest.models.Category;
@@ -49,15 +48,7 @@ public class CategoryAdapter extends RecyclerView.Adapter<CategoryViewHolder> im
 
     @Override
     public void onItemMove(int fromPosition, int toPosition) {
-        if (fromPosition < toPosition) {
-            for (int i = fromPosition; i < toPosition; i++) {
-                Collections.swap(categories, i, i + 1);
-            }
-        } else {
-            for (int i = fromPosition; i > toPosition; i--) {
-                Collections.swap(categories, i, i - 1);
-            }
-        }
+        listener.onCategoryMoved(fromPosition, toPosition);
         notifyItemMoved(fromPosition, toPosition);
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoryClickListener.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoryClickListener.java
@@ -6,4 +6,6 @@ interface CategoryClickListener{
     void onCategoryClicked(Category category);
 
     void onDeleteClicked(Category category);
+
+    void onCategoryMoved(int fromPosition, int toPosition);
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestContract.java
@@ -6,6 +6,7 @@ class DescribeContestContract {
 
     public interface View extends BaseContract.View {
         void setNextEnabled(boolean enabled);
+
         void showNextScreen();
     }
 

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/describecontest/DescribeContestFragment.java
@@ -1,8 +1,6 @@
 package io.intrepid.contest.screens.contestcreation.describecontest;
 
-import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import butterknife.BindView;
 import io.intrepid.contest.R;
@@ -27,12 +25,6 @@ public class DescribeContestFragment extends BaseFragment<DescribeContestPresent
     public DescribeContestPresenter createPresenter(PresenterConfiguration configuration) {
         Contest.Builder contestBuilder = ((EditContestContract) getActivity()).getContestBuilder();
         return new DescribeContestPresenter(this, configuration, contestBuilder);
-    }
-
-    @Override
-    protected void onViewCreated(@Nullable Bundle savedInstanceState) {
-        super.onViewCreated(savedInstanceState);
-        setActionBarTitle(R.string.description);
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesContract.java
@@ -1,7 +1,5 @@
 package io.intrepid.contest.screens.contestcreation.editcategoriestocontest;
 
-import java.util.List;
-
 import io.intrepid.contest.base.BaseContract;
 import io.intrepid.contest.models.Category;
 

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/editcategoriestocontest/EditCategoriesFragment.java
@@ -5,11 +5,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.EditText;
-
-import java.util.List;
 
 import butterknife.BindView;
 import butterknife.OnTextChanged;

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestContract.java
@@ -6,7 +6,7 @@ import io.intrepid.contest.models.Contest;
 interface ReviewContestContract {
 
     interface View extends BaseContract.View {
-        void showReviewPage(Contest.Builder contest);
+        void displayReviewPageContent(Contest.Builder contest);
 
         void showEditTitlePage(Contest.Builder contestBuilder);
 
@@ -17,5 +17,7 @@ interface ReviewContestContract {
         void onContestTitleSelected();
 
         void onContestDescriptionSelected();
+
+        void onPageSelected();
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestFragment.java
@@ -53,7 +53,7 @@ public class ReviewContestFragment extends BaseFragment<ReviewContestPresenter> 
     }
 
     @Override
-    public void showReviewPage(Contest.Builder contestBuilder) {
+    public void displayReviewPageContent(Contest.Builder contestBuilder) {
         titleButton.setText(contestBuilder.title);
         descriptionButton.setText(contestBuilder.description);
         categoryAdapter.setCategories(contestBuilder.getCategories());
@@ -82,6 +82,12 @@ public class ReviewContestFragment extends BaseFragment<ReviewContestPresenter> 
     @Override
     public void onNextClicked() {
         ((EditContestContract) getActivity()).showNextScreen();
-        //todo - submit contest
+    }
+
+    public void onPageSelected() {
+        // The presenter can be null if the view pager was reset and did not load this fragment in advance.
+        if (presenter != null) {
+            presenter.onPageSelected();
+        }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestPresenter.java
@@ -20,7 +20,7 @@ class ReviewContestPresenter extends BasePresenter<ReviewContestContract.View> i
     @Override
     public void onViewCreated() {
         super.onViewCreated();
-        view.showReviewPage(contestBuilder);
+        view.displayReviewPageContent(contestBuilder);
     }
 
     @Override
@@ -31,5 +31,11 @@ class ReviewContestPresenter extends BasePresenter<ReviewContestContract.View> i
     @Override
     public void onContestDescriptionSelected() {
         view.showEditDescriptionPage(contestBuilder);
+    }
+
+    @Override
+    public void onPageSelected() {
+        // Update content when the page is selected to appear
+        view.displayReviewPageContent(contestBuilder);
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/NewContestPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/NewContestPresenterTest.java
@@ -1,6 +1,5 @@
 package io.intrepid.contest.screens.contestcreation;
 
-
 import android.support.annotation.StringRes;
 
 import org.junit.Before;
@@ -14,6 +13,7 @@ import io.intrepid.contest.R;
 import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.rest.ContestWrapper;
+import io.intrepid.contest.screens.contestcreation.reviewcontest.ReviewContestFragment;
 import io.intrepid.contest.testutils.BasePresenterTest;
 import io.reactivex.Observable;
 
@@ -33,9 +33,11 @@ public class NewContestPresenterTest extends BasePresenterTest<NewContestPresent
     @Mock
     ValidatableContestCreationFragment mockValidatableContestCreationFragment;
     @Mock
+    ReviewContestFragment mockReviewContestFragment;
+    @Mock
     Contest.Builder mockContestBuilder;
-    private List<Category> categories;
 
+    private List<Category> categories;
 
     @Before
     public void setup() {
@@ -125,24 +127,16 @@ public class NewContestPresenterTest extends BasePresenterTest<NewContestPresent
     }
 
     @Test
-    public void onPageScrolledShouldCauseViewToShowCorrectPage() {
-        when(mockView.getChildEditFragment(anyInt())).thenReturn(mockChildFragment);
-        presenter.onPageScrolled(0, 0, 0);
-        verify(mockView).setPageTitle(R.string.new_contest);
-    }
-
-    @Test
-    public void onPageScrollStateChangedShouldCauseViewToShowCorrectPageTitle() {
-        when(mockView.getCurrentIndex()).thenReturn(2);
-        presenter.onPageScrollStateChanged(1);
-        verify(mockView).setPageTitle(R.string.scoring_categories);
-    }
-
-    @Test
     public void onPageChangedToValidatableViewShouldTriggerViewToDoOnFocus() {
         when(mockView.getChildEditFragment(anyInt())).thenReturn(mockValidatableContestCreationFragment);
         presenter.onPageSelected(2);
         verify(mockValidatableContestCreationFragment).onFocus();
+    }
+    @Test
+    public void onPageChangedToReviewContestViewShouldTriggerViewToDoOnFocus() {
+        when(mockView.getChildEditFragment(anyInt())).thenReturn(mockReviewContestFragment);
+        presenter.onPageSelected(anyInt());
+        verify(mockReviewContestFragment).onPageSelected();
     }
 
     @Test

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.java
@@ -11,6 +11,7 @@ import io.intrepid.contest.models.Category;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.testutils.BasePresenterTest;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -36,7 +37,7 @@ public class CategoriesListPresenterTest extends BasePresenterTest<CategoriesLis
     private List<Category> makeCategories() {
         List<Category> categories = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-            categories.add(new Category("Test", "Tester"));
+            categories.add(new Category("Category " + i, "Category description " + i));
         }
         return categories;
     }
@@ -106,24 +107,20 @@ public class CategoriesListPresenterTest extends BasePresenterTest<CategoriesLis
 
     @Test
     public void displayCategoriesShouldShowDefaultCategoryWhenThereAreNoCategories() {
-        presenter.displayCategories();
-        verify(mockView).showCategories(any());
-    }
-
-    @Test
-    public void displayCategoriesShouldShowCategories() {
-        presenter.displayCategories();
-        verify(mockView).showCategories(any());
-    }
-
-    @Test
-    public void displayCategoriesShouldShowCategoriesContestshasCategories() {
-        List<Category> categories = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            categories.add(new Category(" ", " "));
-        }
-
+        ArrayList<Category> categories = new ArrayList<>();
+        categories.add(new Category("Default name", "Default description"));
         when(mockContestBuilder.getCategories()).thenReturn(categories);
+
+        presenter.displayCategories();
+
+        verify(mockView).showCategories(argThat(argument -> argument.equals(categories)));
+    }
+
+    @Test
+    public void displayCategoriesShouldShowCategoriesWhenThereAreCategories() {
+        List<Category> categories = makeCategories();
+        when(mockContestBuilder.getCategories()).thenReturn(categories);
+
         presenter.displayCategories();
 
         verify(mockView).showCategories(categories);
@@ -137,16 +134,19 @@ public class CategoriesListPresenterTest extends BasePresenterTest<CategoriesLis
 
     @Test
     public void onNextClickedShouldTriggerViewToShowNextScreen() {
-        List<Category> categoryList = new ArrayList<>();
-        presenter.onNextClicked(categoryList);
+        presenter.onNextClicked();
         verify(mockView).showNextScreen();
     }
 
     @Test
     public void onCategoryClickedShouldTriggerViewToShowEditPage() {
-        Category category = new Category("Test", "Tester");
-        presenter.onCategoryClicked(category);
-        verify(mockView).showEditCategoryPage(category, 0);
+        List<Category> categories = new ArrayList<>();
+        categories.add(new Category("Test", "Tester"));
+        when(mockContestBuilder.getCategories()).thenReturn(categories);
+
+        presenter.onCategoryClicked(categories.get(0));
+
+        verify(mockView).showEditCategoryPage(categories.get(0), 0);
     }
 
     @Test
@@ -154,5 +154,27 @@ public class CategoriesListPresenterTest extends BasePresenterTest<CategoriesLis
         int initialSize = mockContestBuilder.getCategories().size();
         presenter.onDeleteClicked(mockContestBuilder.getCategories().get(0));
         verify(mockView).showCategories(argThat(argument -> argument.size() == initialSize - 1));
+    }
+
+    @Test
+    public void onCategoryMovedShouldUpdateCategoriesListWhenItemMovedUp() {
+        List<Category> categories = makeCategories();
+        when(mockContestBuilder.getCategories()).thenReturn(categories);
+
+        presenter.onCategoryMoved(1, 4);
+
+        assertTrue(categories.get(4).getName().equals("Category 1"));
+        assertTrue(categories.get(1).getName().equals("Category 2"));
+    }
+
+    @Test
+    public void onCategoryMovedShouldUpdateCategoriesListWhenItemMovedDown() {
+        List<Category> categories = makeCategories();
+        when(mockContestBuilder.getCategories()).thenReturn(categories);
+
+        presenter.onCategoryMoved(4, 1);
+
+        assertTrue(categories.get(1).getName().equals("Category 4"));
+        assertTrue(categories.get(4).getName().equals("Category 3"));
     }
 }

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestPresenterTest.java
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/reviewcontest/ReviewContestPresenterTest.java
@@ -4,48 +4,52 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.intrepid.contest.models.Contest;
-import io.intrepid.contest.testutils.TestPresenterConfiguration;
+import io.intrepid.contest.testutils.BasePresenterTest;
 
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ReviewContestPresenterTest {
+public class ReviewContestPresenterTest extends BasePresenterTest<ReviewContestPresenter> {
     @Mock
     ReviewContestContract.View mockView;
     @Mock
     Contest.Builder mockContestBuilder;
     @Mock
     Contest mockContest;
-    private ReviewContestContract.Presenter reviewContestPresenter;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-        reviewContestPresenter = new ReviewContestPresenter(mockView,
-                                                            TestPresenterConfiguration.createTestConfiguration(),
-                                                            mockContestBuilder);
+        presenter = new ReviewContestPresenter(mockView,
+                                               testConfiguration,
+                                               mockContestBuilder);
     }
 
     @Test
     public void onViewCreatedShouldTriggerViewToShowReviewPage() {
-        reviewContestPresenter.onViewCreated();
-        verify(mockView).showReviewPage(mockContestBuilder);
+        presenter.onViewCreated();
+        verify(mockView).displayReviewPageContent(mockContestBuilder);
     }
 
     @Test
     public void onContestTitleSelectedShouldCauseViewToShowEditTitlePage() {
-        reviewContestPresenter.onContestTitleSelected();
+        presenter.onContestTitleSelected();
         verify(mockView).showEditTitlePage(mockContestBuilder);
     }
 
     @Test
     public void onContestDescriptionSelectedShouldCauseViewToShowEditDescriptionPage() {
-        reviewContestPresenter.onContestDescriptionSelected();
+        presenter.onContestDescriptionSelected();
         verify(mockView).showEditDescriptionPage(mockContestBuilder);
+    }
+
+
+    @Test
+    public void onPageSelectedShouldDisplayReviewPageContent() {
+        presenter.onPageSelected();
+        verify(mockView).displayReviewPageContent(mockContestBuilder);
     }
 }
 


### PR DESCRIPTION
https://intrepid.atlassian.net/browse/CON-242

When creating a contest, reordering categories had no effect. Now it is reflected in the categories list screen, and also in the review screen.

I propagated the [`onPageSelected` event to all fragments that belong to the viewpager](https://github.com/IntrepidPursuits/ContestAndroid/compare/master...gabi/242-category-order#diff-1281f68e978e70e739f42217e991356fR21), because I felt weird about creating an interface just for the [one fragment that is using it now](https://github.com/IntrepidPursuits/ContestAndroid/compare/master...gabi/242-category-order#diff-225cdb076d0568c9c2cbb117f5488726R88), and I thought it would be weird for the presenter to check for that specific fragment in the [`NewContestPresenter`](https://github.com/IntrepidPursuits/ContestAndroid/compare/master...gabi/242-category-order#diff-c70bca2626457c22c058404108de876cR136).
Let me know if you have a different opinion though, this might be worse for maintenance...