### PR TITLE
245: Fix crash on creating categories

### DIFF
--- a/app/src/main/java/io/intrepid/contest/base/BaseActivity.kt
+++ b/app/src/main/java/io/intrepid/contest/base/BaseActivity.kt
@@ -36,13 +36,13 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     @CallSuper
-    override fun onNewIntent(intent: Intent) {
+    override fun onNewIntent(intent: Intent?) {
         Timber.v("Lifecycle onNewIntent: " + this)
         super.onNewIntent(intent)
     }
 
     @CallSuper
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         Timber.v("Lifecycle onActivityResult: " + this)
         super.onActivityResult(requestCode, resultCode, data)
     }

--- a/app/src/main/java/io/intrepid/contest/base/BaseFragmentActivity.kt
+++ b/app/src/main/java/io/intrepid/contest/base/BaseFragmentActivity.kt
@@ -28,5 +28,5 @@ abstract class BaseFragmentActivity : BaseActivity() {
         }
     }
 
-    protected abstract fun createFragment(intent: Intent): Fragment
+    protected abstract fun createFragment(intent: Intent?): Fragment
 }

--- a/app/src/main/java/io/intrepid/contest/base/BaseMvpActivity.kt
+++ b/app/src/main/java/io/intrepid/contest/base/BaseMvpActivity.kt
@@ -38,13 +38,13 @@ abstract class BaseMvpActivity<P : BaseContract.Presenter<V>, V : BaseContract.V
     }
 
     @CallSuper
-    override fun onNewIntent(intent: Intent) {
+    override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         presenter.bindView(this as V)
     }
 
     @CallSuper
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         presenter.bindView(this as V)
     }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/NewContestPresenter.java
@@ -113,10 +113,6 @@ public class NewContestPresenter extends BasePresenter<NewContestMvpContract.Vie
     @Override
     public void onPageSelected(int position) {
         ContestCreationFragment childEditFragment = getView().getChildEditFragment(position);
-        if (childEditFragment instanceof ValidatableContestCreationFragment) {
-            ValidatableContestCreationFragment fragment = (ValidatableContestCreationFragment) childEditFragment;
-            fragment.onFocus();
-        }
 
         @StringRes int pageTitle;
         switch (position) {

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/ValidatableContestCreationFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/ValidatableContestCreationFragment.java
@@ -1,6 +1,0 @@
-package io.intrepid.contest.screens.contestcreation;
-
-public interface ValidatableContestCreationFragment extends ContestCreationFragment {
-
-    void onFocus();
-}

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListContract.java
@@ -4,11 +4,10 @@ import java.util.List;
 
 import io.intrepid.contest.base.BaseContract;
 import io.intrepid.contest.models.Category;
-import io.intrepid.contest.screens.contestcreation.ValidatableContestCreationFragment;
 
 interface CategoriesListContract {
 
-    interface View extends BaseContract.View, ValidatableContestCreationFragment {
+    interface View extends BaseContract.View {
         void showCategories(List<Category> categories);
 
         void showAddCategoryScreen();
@@ -20,6 +19,8 @@ interface CategoriesListContract {
         Category getDefaultCategory(int categoryName, int categoryDescription);
 
         void setNextEnabled(boolean enabled);
+
+        void onFocus();
     }
 
     interface Presenter extends BaseContract.Presenter<View>, CategoryClickListener {

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListFragment.java
@@ -105,21 +105,14 @@ public class CategoriesListFragment extends BaseFragment<CategoriesListPresenter
         ((EditContestContract) getActivity()).setNextEnabled(enabled);
     }
 
-    private void hideKeyboard() {
-        if (isAdded()) {
-            ((NewContestActivity) getActivity()).hideKeyboard();
-        }
-    }
-
     @Override
     public void onFocus() {
         hideKeyboard();
-        if (getPresenter() != null) {
-            /* The presenter may not have been created yet, though onFocus was forcefully called.
-              If presenter is null, the onViewBound method will still be called when
-               the fragment is instantiated
-             */
-            getPresenter().onViewBound();
+    }
+
+    private void hideKeyboard() {
+        if (isAdded()) {
+            ((NewContestActivity) getActivity()).hideKeyboard();
         }
     }
 }

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenter.java
@@ -40,6 +40,7 @@ public class CategoriesListPresenter extends BasePresenter<CategoriesListContrac
     protected void onViewBound() {
         super.onViewBound();
         determineNextIconVisibility();
+        getView().onFocus();
     }
 
     @Override

--- a/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
+++ b/app/src/main/java/io/intrepid/contest/screens/contestcreation/namecontest/NameContestFragment.java
@@ -14,13 +14,12 @@ import io.intrepid.contest.customviews.HintLabelEditText;
 import io.intrepid.contest.models.Contest;
 import io.intrepid.contest.screens.contestcreation.ContestCreationFragment;
 import io.intrepid.contest.screens.contestcreation.EditContestContract;
-import io.intrepid.contest.screens.contestcreation.ValidatableContestCreationFragment;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
 public class NameContestFragment extends BaseFragment<NameContestPresenter, NameContestContract.View>
-        implements NameContestContract.View, ContestCreationFragment, ValidatableContestCreationFragment {
+        implements NameContestContract.View, ContestCreationFragment {
     @BindView(R.id.contest_name_edittext)
     HintLabelEditText contestNameField;
     @BindView(R.id.trophy_icon)
@@ -46,11 +45,6 @@ public class NameContestFragment extends BaseFragment<NameContestPresenter, Name
     @OnTextChanged(R.id.hint_label_edit_text)
     public final void onTextChanged(CharSequence newName) {
         getPresenter().onTextChanged(newName);
-    }
-
-    @Override
-    public void onFocus() {
-        getPresenter().onTextChanged(contestNameField.getText());
     }
 
     @Override

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/NewContestPresenterTest.kt
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/NewContestPresenterTest.kt
@@ -1,13 +1,6 @@
 package io.intrepid.contest.screens.contestcreation
 
 import android.support.annotation.StringRes
-
-import org.junit.Before
-import org.junit.Test
-import org.mockito.Mock
-
-import java.util.ArrayList
-
 import io.intrepid.contest.R
 import io.intrepid.contest.models.Category
 import io.intrepid.contest.models.Contest
@@ -16,13 +9,14 @@ import io.intrepid.contest.screens.contestcreation.NewContestMvpContract.View
 import io.intrepid.contest.screens.contestcreation.reviewcontest.ReviewContestFragment
 import io.intrepid.contest.testutils.BasePresenterTest
 import io.reactivex.Observable
-
 import junit.framework.Assert.assertTrue
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyInt
-import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.verify
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.*
+import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import java.util.*
 
 class NewContestPresenterTest : BasePresenterTest<NewContestPresenter>() {
 
@@ -30,8 +24,6 @@ class NewContestPresenterTest : BasePresenterTest<NewContestPresenter>() {
     private lateinit var mockView: View
     @Mock
     private lateinit var mockChildFragment: ContestCreationFragment
-    @Mock
-    private lateinit var mockValidatableContestCreationFragment: ValidatableContestCreationFragment
     @Mock
     private lateinit var mockReviewContestFragment: ReviewContestFragment
     @Mock
@@ -123,13 +115,6 @@ class NewContestPresenterTest : BasePresenterTest<NewContestPresenter>() {
         testOnPageScrolledWithExpectedPageTitleStringResource(1, R.string.description)
         testOnPageScrolledWithExpectedPageTitleStringResource(2, R.string.scoring_categories)
         testOnPageScrolledWithExpectedPageTitleStringResource(3, R.string.review_contest)
-    }
-
-    @Test
-    fun onPageChangedToValidatableViewShouldTriggerViewToDoOnFocus() {
-        `when`(mockView.getChildEditFragment(anyInt())).thenReturn(mockValidatableContestCreationFragment)
-        presenter.onPageSelected(2)
-        verify<ValidatableContestCreationFragment>(mockValidatableContestCreationFragment).onFocus()
     }
 
     @Test

--- a/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.kt
+++ b/app/src/test/java/io/intrepid/contest/screens/contestcreation/categorieslist/CategoriesListPresenterTest.kt
@@ -100,6 +100,12 @@ class CategoriesListPresenterTest : BasePresenterTest<CategoriesListPresenter>()
     }
 
     @Test
+    fun onViewBoundShouldTriggerViewToFocus() {
+        presenter.onViewBound()
+        verify<View>(mockView).onFocus()
+    }
+
+    @Test
     fun displayCategoriesShouldShowDefaultCategoryWhenThereAreNoCategories() {
         val categories = listOf(Category("Default name", "Default description"))
         `when`(mockContestBuilder.getCategories()).thenReturn(categories)


### PR DESCRIPTION
[ 🎉 Friday Time! 🎈 ]

https://intrepid.atlassian.net/browse/CON-245

- Crash on canceling category creation was caused by `onActivityResult()` not allowing null parameters. Base classes have been updated according to skotlinton to allow nonnull parameters.

- Crash on submitting category was caused by `lateinit presenter` not being initialized before use (use being checking for null). There's still one comparison of `getPresenter() != null` in another class but that will be solved in another PR.